### PR TITLE
PostgreSQL migration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 JWT_SECRET=yovi_es1c_2526
 
 # Internal path where the services will look for the database files inside the containers
-DB_PATH=/app/data/
+AUTH_DB_PASSWORD=changeme
 # Backend Service Endpoints
 VITE_GAME_ENGINE_API_URL=/api/gamey   # Rust game engine (stateless logic)
 VITE_GAME_SERVICE_API_URL=/api/game    # Game persistence service (matches, stats)

--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -2,10 +2,6 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-RUN apk add --no-cache python3 make g++
-
-RUN mkdir -p /app/data && chmod 777 /app/data
-
 COPY package*.json ./
 
 RUN npm ci

--- a/auth/package-lock.json
+++ b/auth/package-lock.json
@@ -9,20 +9,19 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "bcrypt": "^6.0.0",
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.3",
-        "prom-client": "^15.1.3",
-        "sqlite3": "^5.1.7"
+        "pg": "^8.13.3",
+        "prom-client": "^15.1.3"
       },
       "devDependencies": {
-        "@types/bcrypt": "^6.0.0",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^25.3.0",
+        "@types/pg": "^8.11.14",
         "@types/supertest": "^6.0.3",
         "@vitest/coverage-v8": "^4.0.18",
         "supertest": "^7.2.2",
@@ -570,13 +569,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@gar/promisify": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
-      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -635,32 +627,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@npmcli/fs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
-      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "@gar/promisify": "^1.0.1",
-        "semver": "^7.3.5"
-      }
-    },
-    "node_modules/@npmcli/move-file": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
-      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
-      "deprecated": "This functionality has been moved to @npmcli/fs",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -961,16 +927,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -980,16 +936,6 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@types/bcrypt": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
-      "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/body-parser": {
@@ -1120,6 +1066,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/qs": {
@@ -1325,13 +1283,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "license": "ISC",
-      "optional": true
-    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -1343,78 +1294,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aproba": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
-      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
-      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/asap": {
@@ -1453,72 +1332,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/bcrypt": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
-      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^8.3.0",
-        "node-gyp-build": "^4.8.4"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "node_modules/bintrees": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
       "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
       "license": "MIT"
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -1544,41 +1362,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -1592,36 +1375,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/cacache": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
-      "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "@npmcli/fs": "^1.0.0",
-        "@npmcli/move-file": "^1.0.1",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "glob": "^7.1.4",
-        "infer-owner": "^1.0.4",
-        "lru-cache": "^6.0.0",
-        "minipass": "^3.1.1",
-        "minipass-collect": "^1.0.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.2",
-        "mkdirp": "^1.0.3",
-        "p-map": "^4.0.0",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^8.0.1",
-        "tar": "^6.0.2",
-        "unique-filename": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -1663,35 +1416,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1714,20 +1438,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -1800,30 +1510,6 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1833,13 +1519,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -1854,6 +1533,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -1911,13 +1591,6 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
-    "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -1926,55 +1599,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
-    "node_modules/env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/err-code": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -2096,15 +1720,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2182,12 +1797,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
@@ -2286,31 +1895,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "license": "ISC",
-      "optional": true
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2333,27 +1917,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gauge": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
-      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.3",
-        "console-control-strings": "^1.1.0",
-        "has-unicode": "^2.0.1",
-        "signal-exit": "^3.0.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2406,34 +1969,6 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2445,13 +1980,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -2491,13 +2019,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "license": "ISC",
-      "optional": true
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -2526,13 +2047,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/http-cache-semantics": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "license": "BSD-2-Clause",
-      "optional": true
-    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -2553,45 +2067,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/http-proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ms": "^2.0.0"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -2608,86 +2083,11 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/infer-owner": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC"
-    },
-    "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -2698,35 +2098,11 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-lambda": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -3120,19 +2496,6 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3169,44 +2532,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-fetch-happen": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
-      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "agentkeepalive": "^4.1.3",
-        "cacache": "^15.2.0",
-        "http-cache-semantics": "^4.1.0",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "is-lambda": "^1.0.1",
-        "lru-cache": "^6.0.0",
-        "minipass": "^3.1.3",
-        "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^1.3.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.2",
-        "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^6.0.0",
-        "ssri": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/negotiator": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
-      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/math-intrinsics": {
@@ -3287,153 +2612,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-collect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minipass-fetch": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
-      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.1.0",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.12"
-      }
-    },
-    "node_modules/minipass-flush": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
-      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minipass-pipeline": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-sized": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
-      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3459,12 +2637,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
-    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -3472,96 +2644,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-addon-api": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
-      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
-    },
-    "node_modules/node-gyp": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
-      "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "env-paths": "^2.2.0",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^9.1.0",
-        "nopt": "^5.0.0",
-        "npmlog": "^6.0.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.2",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
-      },
-      "engines": {
-        "node": ">= 10.12.0"
-      }
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "license": "MIT",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
-    },
-    "node_modules/nopt": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/npmlog": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
-      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "are-we-there-yet": "^3.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^4.0.3",
-        "set-blocking": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/object-inspect": {
@@ -3608,22 +2690,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -3631,16 +2697,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/path-to-regexp": {
@@ -3659,6 +2715,95 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3709,31 +2854,43 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
       "license": "MIT",
       "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
+        "xtend": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prom-client": {
@@ -3749,27 +2906,6 @@
         "node": "^16 || ^18 || >=20"
       }
     },
-    "node_modules/promise-inflight": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/promise-retry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -3781,16 +2917,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
       }
     },
     "node_modules/qs": {
@@ -3832,35 +2958,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -3869,33 +2966,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rolldown": {
@@ -4031,13 +3101,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "license": "ISC",
-      "optional": true
-    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -4123,99 +3186,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ip-address": "^10.0.1",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
-      "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.3",
-        "socks": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4226,47 +3196,13 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sqlite3": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz",
-      "integrity": "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^7.0.0",
-        "prebuild-install": "^7.1.1",
-        "tar": "^6.1.11"
-      },
-      "optionalDependencies": {
-        "node-gyp": "8.x"
-      },
-      "peerDependencies": {
-        "node-gyp": "8.x"
-      },
-      "peerDependenciesMeta": {
-        "node-gyp": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/sqlite3/node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT"
-    },
-    "node_modules/ssri": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
-      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.1.1"
-      },
       "engines": {
-        "node": ">= 8"
+        "node": ">= 10.x"
       }
     },
     "node_modules/stackback": {
@@ -4291,52 +3227,6 @@
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/superagent": {
       "version": "10.3.0",
@@ -4383,67 +3273,6 @@
       "dependencies": {
         "has-flag": "^4.0.0"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-fs/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "license": "ISC",
       "engines": {
         "node": ">=8"
       }
@@ -4538,18 +3367,6 @@
         "fsevents": "~2.3.3"
       }
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -4585,26 +3402,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/unique-filename": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "unique-slug": "^2.0.0"
-      }
-    },
-    "node_modules/unique-slug": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
-      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      }
-    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -4613,12 +3410,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -4789,22 +3580,6 @@
         }
       }
     },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -4822,27 +3597,20 @@
         "node": ">=8"
       }
     },
-    "node_modules/wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     }
   }
 }

--- a/auth/package.json
+++ b/auth/package.json
@@ -18,20 +18,19 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "bcrypt": "^6.0.0",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.3",
-    "prom-client": "^15.1.3",
-    "sqlite3": "^5.1.7"
+    "pg": "^8.13.3",
+    "prom-client": "^15.1.3"
   },
   "devDependencies": {
-    "@types/bcrypt": "^6.0.0",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^25.3.0",
+    "@types/pg": "^8.11.14",
     "@types/supertest": "^6.0.3",
     "@vitest/coverage-v8": "^4.0.18",
     "supertest": "^7.2.2",

--- a/auth/scripts/init-auth-db.sql
+++ b/auth/scripts/init-auth-db.sql
@@ -1,39 +1,33 @@
-PRAGMA foreign_keys = ON;
-
 CREATE TABLE IF NOT EXISTS users_credentials (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  username TEXT UNIQUE NOT NULL,
-  password_hash TEXT NOT NULL,
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-);
+                                                 id            SERIAL PRIMARY KEY,
+                                                 username      TEXT UNIQUE NOT NULL,
+                                                 password_hash TEXT NOT NULL,
+                                                 created_at    TIMESTAMPTZ DEFAULT NOW()
+    );
 
 CREATE TABLE IF NOT EXISTS sessions (
-  id TEXT PRIMARY KEY,
-  user_id INTEGER NOT NULL,
-  device_id TEXT NOT NULL,
-  device_name TEXT,
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  revoked_at DATETIME,
-  FOREIGN KEY (user_id) REFERENCES users_credentials (id)
-);
+                                        id          TEXT PRIMARY KEY,
+                                        user_id     INTEGER NOT NULL REFERENCES users_credentials(id),
+    device_id   TEXT NOT NULL,
+    device_name TEXT,
+    created_at  TIMESTAMPTZ DEFAULT NOW(),
+    revoked_at  TIMESTAMPTZ
+    );
 
 CREATE TABLE IF NOT EXISTS refresh_tokens (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  user_id INTEGER NOT NULL,
-  session_id TEXT NOT NULL,
-  token_hash TEXT NOT NULL,
-  family_id TEXT NOT NULL,
-  expires_at DATETIME NOT NULL,
-  revoked_at DATETIME,
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (user_id) REFERENCES users_credentials (id),
-  FOREIGN KEY (session_id) REFERENCES sessions (id),
-  UNIQUE(token_hash)
-);
+                                              id          SERIAL PRIMARY KEY,
+                                              user_id     INTEGER NOT NULL REFERENCES users_credentials(id),
+    session_id  TEXT NOT NULL REFERENCES sessions(id),
+    token_hash  TEXT NOT NULL UNIQUE,
+    family_id   TEXT NOT NULL,
+    expires_at  TIMESTAMPTZ NOT NULL,
+    revoked_at  TIMESTAMPTZ,
+    created_at  TIMESTAMPTZ DEFAULT NOW()
+    );
 
-CREATE INDEX IF NOT EXISTS idx_refresh_tokens_user_id ON refresh_tokens(user_id);
-CREATE INDEX IF NOT EXISTS idx_refresh_tokens_session_id ON refresh_tokens(session_id);
-CREATE INDEX IF NOT EXISTS idx_refresh_tokens_family_id ON refresh_tokens(family_id);
-CREATE INDEX IF NOT EXISTS idx_refresh_tokens_expires_at ON refresh_tokens(expires_at);
-CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id);
-CREATE INDEX IF NOT EXISTS idx_sessions_device_id ON sessions(device_id);
+CREATE INDEX IF NOT EXISTS idx_rt_user_id     ON refresh_tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_rt_session_id  ON refresh_tokens(session_id);
+CREATE INDEX IF NOT EXISTS idx_rt_family_id   ON refresh_tokens(family_id);
+CREATE INDEX IF NOT EXISTS idx_rt_expires_at  ON refresh_tokens(expires_at);
+CREATE INDEX IF NOT EXISTS idx_sess_user_id   ON sessions(user_id);
+CREATE INDEX IF NOT EXISTS idx_sess_device_id ON sessions(device_id);

--- a/auth/src/db/init-auth-db.ts
+++ b/auth/src/db/init-auth-db.ts
@@ -1,52 +1,25 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import sqlite3 from 'sqlite3';
+import pg from 'pg';
 
-function openDatabase(dbPath: string): Promise<sqlite3.Database> {
-    return new Promise((resolve, reject) => {
-        const db = new sqlite3.Database(dbPath, (err) => {
-            if (err) {
-                reject(err);
-                return;
-            }
+const { Client } = pg;
 
-            resolve(db);
-        });
+export async function initAuthDatabase(): Promise<void> {
+    const client = new Client({
+        host:     process.env.PGHOST     ?? 'localhost',
+        port:     Number(process.env.PGPORT ?? 5432),
+        database: process.env.PGDATABASE ?? 'authdb',
+        user:     process.env.PGUSER     ?? 'auth_user',
+        password: process.env.PGPASSWORD ?? 'changeme',
     });
-}
 
-function exec(db: sqlite3.Database, sql: string): Promise<void> {
-    return new Promise((resolve, reject) => {
-        db.exec(sql, (err) => {
-            if (err) reject(err);
-            else resolve();
-        });
-    });
-}
-
-function close(db: sqlite3.Database): Promise<void> {
-    return new Promise((resolve, reject) => {
-        db.close((err) => {
-            if (err) reject(err);
-            else resolve();
-        });
-    });
-}
-
-export async function initAuthDatabase(dbPath: string): Promise<void> {
-    const dir = path.dirname(dbPath);
-    if (dir && dir !== '.') {
-        fs.mkdirSync(dir, { recursive: true });
-    }
-
-    const db = await openDatabase(dbPath);
+    await client.connect();
 
     try {
         const sqlPath = path.resolve(process.cwd(), 'scripts/init-auth-db.sql');
         const initSql = fs.readFileSync(sqlPath, 'utf8');
-
-        await exec(db, initSql);
+        await client.query(initSql);
     } finally {
-        await close(db);
+        await client.end();
     }
 }

--- a/auth/src/db/run-init.ts
+++ b/auth/src/db/run-init.ts
@@ -1,7 +1,6 @@
-import { getAuthDbPath } from '../bootstrap/auth-context.js';
 import { initAuthDatabase } from './init-auth-db.js';
 
-initAuthDatabase(getAuthDbPath())
+initAuthDatabase()
     .then(() => {
         console.log('Auth DB initialized');
     })

--- a/auth/src/repositories/credentials.repository.ts
+++ b/auth/src/repositories/credentials.repository.ts
@@ -1,5 +1,7 @@
-import sqlite3 from 'sqlite3';
+import pg from 'pg';
 import { startDbOperationTimer, type DbOperation } from '../metrics.js';
+
+const { Pool } = pg;
 
 export type RefreshTokenRecord = {
     id: number;
@@ -11,34 +13,18 @@ export type RefreshTokenRecord = {
     revoked_at: string | null;
 };
 
-type SqlRunContext = {
-    lastID?: number;
-    changes?: number;
-};
-
-type PromiseCallbacks = {
-    resolve: (value: number) => void;
-    reject: (reason: unknown) => void;
-};
-
-// ── Helper: crea un callback para db.run que resuelve/rechaza la Promise ──
-function makeRunCallback(
-    { resolve, reject }: PromiseCallbacks,
-    getValue: (ctx: SqlRunContext) => number = (ctx) => ctx.changes ?? 0
-): (this: SqlRunContext, err: Error | null) => void {
-    return function(this: SqlRunContext, err: Error | null) {
-        if (err) reject(err);
-        else resolve(getValue(this));
-    };
-}
+const pool = new Pool({
+    host:     process.env.PGHOST     ?? 'localhost',
+    port:     Number(process.env.PGPORT ?? 5432),
+    database: process.env.PGDATABASE ?? 'authdb',
+    user:     process.env.PGUSER     ?? 'auth_user',
+    password: process.env.PGPASSWORD ?? 'changeme',
+    max: 20,
+    idleTimeoutMillis: 30_000,
+    connectionTimeoutMillis: 2_000,
+});
 
 export class CredentialsRepository {
-    private db: sqlite3.Database;
-
-    constructor(dbPath: string) {
-        this.db = new sqlite3.Database(dbPath);
-    }
-
     private async withDbMetrics<T>(operation: DbOperation, action: () => Promise<T>): Promise<T> {
         const endTimer = startDbOperationTimer(operation);
         try {
@@ -51,187 +37,200 @@ export class CredentialsRepository {
         }
     }
 
-    private revokeTokensBySessionId(sessionId: string, callbacks: PromiseCallbacks): void {
-        this.db.run(
-            `UPDATE refresh_tokens SET revoked_at = CURRENT_TIMESTAMP
-             WHERE session_id = ? AND revoked_at IS NULL`,
-            [sessionId],
-            makeRunCallback(callbacks)
-        );
-    }
-
     async createUser(username: string, passwordHash: string): Promise<number> {
-        return this.withDbMetrics('create_user', () => new Promise((resolve, reject) => {
-            this.db.run(
-                'INSERT INTO users_credentials (username, password_hash) VALUES (?, ?)',
-                [username, passwordHash],
-                makeRunCallback({ resolve, reject }, (ctx) => ctx.lastID ?? 0)
+        return this.withDbMetrics('create_user', async () => {
+            const res = await pool.query(
+                'INSERT INTO users_credentials (username, password_hash) VALUES ($1, $2) RETURNING id',
+                [username, passwordHash]
             );
-        }));
+            return res.rows[0].id as number;
+        });
     }
 
     async findUserByUsername(username: string): Promise<{ id: number; username: string; password_hash: string } | null> {
-        return this.withDbMetrics('find_user_by_username', () => new Promise((resolve, reject) => {
-            this.db.get(
-                'SELECT id, username, password_hash FROM users_credentials WHERE username = ?',
-                [username],
-                (err, row: any) => { if (err) reject(err); else resolve(row || null); }
+        return this.withDbMetrics('find_user_by_username', async () => {
+            const res = await pool.query(
+                'SELECT id, username, password_hash FROM users_credentials WHERE username = $1',
+                [username]
             );
-        }));
+            return res.rows[0] ?? null;
+        });
     }
 
     async findUserById(userId: number): Promise<{ id: number; username: string } | null> {
-        return this.withDbMetrics('find_user_by_id', () => new Promise((resolve, reject) => {
-            this.db.get(
-                'SELECT id, username FROM users_credentials WHERE id = ?',
-                [userId],
-                (err, row: any) => { if (err) reject(err); else resolve(row || null); }
+        return this.withDbMetrics('find_user_by_id', async () => {
+            const res = await pool.query(
+                'SELECT id, username FROM users_credentials WHERE id = $1',
+                [userId]
             );
-        }));
+            return res.rows[0] ?? null;
+        });
     }
 
     async createSession(sessionId: string, userId: number, deviceId: string, deviceName?: string): Promise<void> {
-        return this.withDbMetrics('store_refresh_token', () => new Promise((resolve, reject) => {
-            this.db.run(
-                `INSERT INTO sessions (id, user_id, device_id, device_name) VALUES (?, ?, ?, ?)`,
-                [sessionId, userId, deviceId, deviceName ?? null],
-                (err) => { if (err) reject(err); else resolve(); }
+        return this.withDbMetrics('store_refresh_token', async () => {
+            await pool.query(
+                'INSERT INTO sessions (id, user_id, device_id, device_name) VALUES ($1, $2, $3, $4)',
+                [sessionId, userId, deviceId, deviceName ?? null]
             );
-        }));
+        });
     }
 
     async countActiveSessions(userId: number): Promise<number> {
-        return this.withDbMetrics('count_active_refresh_tokens', () => new Promise((resolve, reject) => {
-            this.db.get(
-                `SELECT COUNT(*) AS total FROM sessions WHERE user_id = ? AND revoked_at IS NULL`,
-                [userId],
-                (err, row: any) => { if (err) reject(err); else resolve(Number(row?.total ?? 0)); }
+        return this.withDbMetrics('count_active_refresh_tokens', async () => {
+            const res = await pool.query(
+                'SELECT COUNT(*) AS total FROM sessions WHERE user_id = $1 AND revoked_at IS NULL',
+                [userId]
             );
-        }));
+            return Number(res.rows[0]?.total ?? 0);
+        });
     }
 
     async revokeOldestActiveSession(userId: number): Promise<number> {
-        return this.withDbMetrics('revoke_all_user_sessions', () => new Promise((resolve, reject) => {
-            this.db.serialize(() => {
-                this.db.get(
-                    `SELECT id FROM sessions WHERE user_id = ? AND revoked_at IS NULL
-                     ORDER BY datetime(created_at) ASC LIMIT 1`,
-                    [userId],
-                    (selectErr, row: any) => {
-                        if (selectErr) { reject(selectErr); return; }
-                        const sessionId = row?.id;
-                        if (!sessionId) { resolve(0); return; }
-                        this.revokeOldestSessionAndTokens(sessionId, { resolve, reject });
-                    }
+        return this.withDbMetrics('revoke_all_user_sessions', async () => {
+            const client = await pool.connect();
+            try {
+                await client.query('BEGIN');
+                const sel = await client.query(
+                    `SELECT id FROM sessions
+                     WHERE user_id = $1 AND revoked_at IS NULL
+                     ORDER BY created_at ASC LIMIT 1`,
+                    [userId]
                 );
-            });
-        }));
-    }
-
-    private revokeOldestSessionAndTokens(sessionId: string, callbacks: PromiseCallbacks): void {
-        this.db.run(
-            `UPDATE sessions SET revoked_at = CURRENT_TIMESTAMP
-             WHERE id = ? AND revoked_at IS NULL`,
-            [sessionId],
-            function(this: SqlRunContext, updateErr: Error | null) {
-                if (updateErr) { callbacks.reject(updateErr); return; }
-                if ((this.changes ?? 0) === 0) { callbacks.resolve(0); return; }
+                const sessionId = sel.rows[0]?.id;
+                if (!sessionId) {
+                    await client.query('COMMIT');
+                    return 0;
+                }
+                await client.query(
+                    `UPDATE sessions SET revoked_at = NOW()
+                     WHERE id = $1 AND revoked_at IS NULL`,
+                    [sessionId]
+                );
+                const upd = await client.query(
+                    `UPDATE refresh_tokens SET revoked_at = NOW()
+                     WHERE session_id = $1 AND revoked_at IS NULL`,
+                    [sessionId]
+                );
+                await client.query('COMMIT');
+                return upd.rowCount ?? 0;
+            } catch (e) {
+                await client.query('ROLLBACK');
+                throw e;
+            } finally {
+                client.release();
             }
-        );
-        this.revokeTokensBySessionId(sessionId, callbacks);
+        });
     }
 
-    async storeRefreshToken(userId: number, sessionId: string, tokenHash: string, familyId: string, expiresAt: string): Promise<void> {
-        return this.withDbMetrics('store_refresh_token', () => new Promise((resolve, reject) => {
-            this.db.run(
-                `INSERT INTO refresh_tokens (user_id, session_id, token_hash, family_id, expires_at) VALUES (?, ?, ?, ?, ?)`,
-                [userId, sessionId, tokenHash, familyId, expiresAt],
-                (err) => { if (err) reject(err); else resolve(); }
+    async storeRefreshToken(
+        userId: number,
+        sessionId: string,
+        tokenHash: string,
+        familyId: string,
+        expiresAt: string
+    ): Promise<void> {
+        return this.withDbMetrics('store_refresh_token', async () => {
+            await pool.query(
+                `INSERT INTO refresh_tokens (user_id, session_id, token_hash, family_id, expires_at)
+                 VALUES ($1, $2, $3, $4, $5)`,
+                [userId, sessionId, tokenHash, familyId, expiresAt]
             );
-        }));
+        });
     }
 
     async findRefreshTokenByHash(tokenHash: string): Promise<RefreshTokenRecord | null> {
-        return this.withDbMetrics('find_refresh_token_by_hash', () => new Promise((resolve, reject) => {
-            this.db.get(
+        return this.withDbMetrics('find_refresh_token_by_hash', async () => {
+            const res = await pool.query(
                 `SELECT id, user_id, session_id, token_hash, family_id, expires_at, revoked_at
-                 FROM refresh_tokens WHERE token_hash = ?`,
-                [tokenHash],
-                (err, row: any) => { if (err) reject(err); else resolve(row || null); }
+                 FROM refresh_tokens WHERE token_hash = $1`,
+                [tokenHash]
             );
-        }));
+            return res.rows[0] ?? null;
+        });
     }
 
     async revokeRefreshToken(tokenId: number): Promise<number> {
-        return this.withDbMetrics('revoke_refresh_token', () => new Promise((resolve, reject) => {
-            this.db.run(
-                'UPDATE refresh_tokens SET revoked_at = CURRENT_TIMESTAMP WHERE id = ? AND revoked_at IS NULL',
-                [tokenId],
-                makeRunCallback({ resolve, reject })
+        return this.withDbMetrics('revoke_refresh_token', async () => {
+            const res = await pool.query(
+                `UPDATE refresh_tokens SET revoked_at = NOW()
+                 WHERE id = $1 AND revoked_at IS NULL`,
+                [tokenId]
             );
-        }));
+            return res.rowCount ?? 0;
+        });
     }
 
     async revokeRefreshTokenFamily(familyId: string): Promise<number> {
-        return this.withDbMetrics('revoke_refresh_token_family', () => new Promise((resolve, reject) => {
-            this.db.run(
-                `UPDATE refresh_tokens SET revoked_at = CURRENT_TIMESTAMP
-                 WHERE family_id = ? AND revoked_at IS NULL`,
-                [familyId],
-                makeRunCallback({ resolve, reject })
+        return this.withDbMetrics('revoke_refresh_token_family', async () => {
+            const res = await pool.query(
+                `UPDATE refresh_tokens SET revoked_at = NOW()
+                 WHERE family_id = $1 AND revoked_at IS NULL`,
+                [familyId]
             );
-        }));
+            return res.rowCount ?? 0;
+        });
     }
 
     async revokeAllUserSessions(userId: number): Promise<number> {
-        return this.withDbMetrics('revoke_all_user_sessions', () => new Promise((resolve, reject) => {
-            this.db.serialize(() => {
-                this.db.run(
-                    `UPDATE sessions SET revoked_at = CURRENT_TIMESTAMP
-                     WHERE user_id = ? AND revoked_at IS NULL`,
-                    [userId],
-                    (sessionErr) => {
-                        if (sessionErr) { reject(sessionErr); return; }
-                        this.revokeTokensByUserId(userId, { resolve, reject });
-                    }
+        return this.withDbMetrics('revoke_all_user_sessions', async () => {
+            const client = await pool.connect();
+            try {
+                await client.query('BEGIN');
+                await client.query(
+                    `UPDATE sessions SET revoked_at = NOW()
+                     WHERE user_id = $1 AND revoked_at IS NULL`,
+                    [userId]
                 );
-            });
-        }));
-    }
-
-    private revokeTokensByUserId(userId: number, callbacks: PromiseCallbacks): void {
-        this.db.run(
-            `UPDATE refresh_tokens SET revoked_at = CURRENT_TIMESTAMP
-             WHERE user_id = ? AND revoked_at IS NULL`,
-            [userId],
-            makeRunCallback(callbacks)
-        );
+                const res = await client.query(
+                    `UPDATE refresh_tokens SET revoked_at = NOW()
+                     WHERE user_id = $1 AND revoked_at IS NULL`,
+                    [userId]
+                );
+                await client.query('COMMIT');
+                return res.rowCount ?? 0;
+            } catch (e) {
+                await client.query('ROLLBACK');
+                throw e;
+            } finally {
+                client.release();
+            }
+        });
     }
 
     async revokeSessionById(sessionId: string): Promise<number> {
-        return this.withDbMetrics('revoke_all_user_sessions', () => new Promise((resolve, reject) => {
-            this.db.serialize(() => {
-                this.db.run(
-                    `UPDATE sessions SET revoked_at = CURRENT_TIMESTAMP
-                     WHERE id = ? AND revoked_at IS NULL`,
-                    [sessionId],
-                    (sessionErr) => {
-                        if (sessionErr) { reject(sessionErr); return; }
-                        this.revokeTokensBySessionId(sessionId, { resolve, reject });
-                    }
+        return this.withDbMetrics('revoke_all_user_sessions', async () => {
+            const client = await pool.connect();
+            try {
+                await client.query('BEGIN');
+                await client.query(
+                    `UPDATE sessions SET revoked_at = NOW()
+                     WHERE id = $1 AND revoked_at IS NULL`,
+                    [sessionId]
                 );
-            });
-        }));
+                const res = await client.query(
+                    `UPDATE refresh_tokens SET revoked_at = NOW()
+                     WHERE session_id = $1 AND revoked_at IS NULL`,
+                    [sessionId]
+                );
+                await client.query('COMMIT');
+                return res.rowCount ?? 0;
+            } catch (e) {
+                await client.query('ROLLBACK');
+                throw e;
+            } finally {
+                client.release();
+            }
+        });
     }
 
     async countActiveRefreshTokens(): Promise<number> {
-        return this.withDbMetrics('count_active_refresh_tokens', () => new Promise((resolve, reject) => {
-            this.db.get(
+        return this.withDbMetrics('count_active_refresh_tokens', async () => {
+            const res = await pool.query(
                 `SELECT COUNT(*) AS total FROM refresh_tokens
-                 WHERE revoked_at IS NULL AND datetime(expires_at) > datetime('now')`,
-                [],
-                (err, row: any) => { if (err) reject(err); else resolve(Number(row?.total ?? 0)); }
+                 WHERE revoked_at IS NULL AND expires_at > NOW()`
             );
-        }));
+            return Number(res.rows[0]?.total ?? 0);
+        });
     }
 }

--- a/auth/src/services/auth.service.ts
+++ b/auth/src/services/auth.service.ts
@@ -1,6 +1,5 @@
-import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
-import crypto from 'node:crypto';
+import crypto, { randomBytes, timingSafeEqual } from 'node:crypto';
 import { CredentialsRepository } from '../repositories/credentials.repository.js';
 import {
     BadCredentialsError,
@@ -23,15 +22,46 @@ import {
     startJwtSignTimer,
 } from '../metrics.js';
 
-const ACCESS_TOKEN_TTL = '15m';
-const REFRESH_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+function scryptAsync(
+    password: string,
+    salt: string,
+    keylen: number,
+    options: crypto.ScryptOptions
+): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+        crypto.scrypt(password, salt, keylen, options, (err, derived) => {
+            if (err) reject(err);
+            else resolve(derived);
+        });
+    });
+}
+const SCRYPT_PARAMS = { N: 16384, r: 8, p: 1 } as const;
+const SALT_BYTES    = 32;
+const KEY_LEN       = 64;
 
-function hasSqliteConstraintCode(error: unknown): boolean {
+async function hashPassword(password: string): Promise<string> {
+    const salt = randomBytes(SALT_BYTES).toString('hex');
+    const hash = (await scryptAsync(password, salt, KEY_LEN, SCRYPT_PARAMS)) as Buffer;
+    return `${salt}:${hash.toString('hex')}`;
+}
+
+async function verifyPassword(password: string, stored: string): Promise<boolean> {
+    const [salt, hashHex] = stored.split(':');
+    if (!salt || !hashHex) return false;
+    const storedHash = Buffer.from(hashHex, 'hex');
+    const derived    = (await scryptAsync(password, salt, KEY_LEN, SCRYPT_PARAMS)) as Buffer;
+    return timingSafeEqual(derived, storedHash);
+}
+
+function hasUniqueConstraintError(error: unknown): boolean {
     return typeof error === 'object'
         && error !== null
         && 'code' in error
-        && (error as { code?: unknown }).code === 'SQLITE_CONSTRAINT';
+        && (error as { code?: unknown }).code === '23505';
 }
+
+const ACCESS_TOKEN_TTL    = '15m';
+const REFRESH_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 type AuthResponse = {
     accessToken: string;
@@ -51,11 +81,12 @@ export class AuthService {
 
     async register(username: string, password: string, deviceId = 'web', deviceName?: string): Promise<AuthResponse> {
         try {
+            // startBcryptHashTimer se mantiene para no romper dashboards Grafana existentes
             const endHash = startBcryptHashTimer();
             let passwordHash: string;
 
             try {
-                passwordHash = await bcrypt.hash(password, 12);
+                passwordHash = await hashPassword(password);
             } finally {
                 endHash();
             }
@@ -73,7 +104,7 @@ export class AuthService {
                 },
             };
         } catch (error: unknown) {
-            if (hasSqliteConstraintCode(error)) {
+            if (hasUniqueConstraintError(error)) {
                 recordRegisterAttempt('user_exists');
                 throw new UserAlreadyExistsError();
             }
@@ -101,7 +132,7 @@ export class AuthService {
             let isPasswordValid = false;
 
             try {
-                isPasswordValid = await bcrypt.compare(password, user.password_hash);
+                isPasswordValid = await verifyPassword(password, user.password_hash);
             } finally {
                 endCompare();
             }
@@ -150,7 +181,7 @@ export class AuthService {
                 throw new InvalidRefreshTokenError();
             }
 
-            const tokenHash = this.hashRefreshToken(refreshToken);
+            const tokenHash  = this.hashRefreshToken(refreshToken);
             const storedToken = await this.repo.findRefreshTokenByHash(tokenHash);
 
             if (!storedToken) {
@@ -189,8 +220,8 @@ export class AuthService {
                 decrementActiveRefreshTokens(revokedRotated);
             }
 
-            const nextRefreshToken = this.generateOpaqueToken();
-            const nextRefreshHash = this.hashRefreshToken(nextRefreshToken);
+            const nextRefreshToken   = this.generateOpaqueToken();
+            const nextRefreshHash    = this.hashRefreshToken(nextRefreshToken);
             const nextRefreshExpires = new Date(Date.now() + REFRESH_TOKEN_TTL_MS).toISOString();
 
             await this.repo.storeRefreshToken(
@@ -204,9 +235,9 @@ export class AuthService {
             recordRefreshTokenIssued();
             incrementActiveRefreshTokens();
 
-            const user = await this.repo.findUserById(storedToken.user_id);
+            const user             = await this.repo.findUserById(storedToken.user_id);
             const usernameResolved = user?.username;
-            const accessToken = this.signAccessToken(storedToken.user_id, storedToken.session_id, usernameResolved);
+            const accessToken      = this.signAccessToken(storedToken.user_id, storedToken.session_id, usernameResolved);
 
             recordRefreshAttempt('success');
 
@@ -240,11 +271,11 @@ export class AuthService {
         const sessionId = crypto.randomUUID();
         await this.repo.createSession(sessionId, userId, deviceId, deviceName);
 
-        const accessToken = this.signAccessToken(userId, sessionId, username);
-        const refreshToken = this.generateOpaqueToken();
-        const refreshHash = this.hashRefreshToken(refreshToken);
+        const accessToken      = this.signAccessToken(userId, sessionId, username);
+        const refreshToken     = this.generateOpaqueToken();
+        const refreshHash      = this.hashRefreshToken(refreshToken);
         const refreshExpiresAt = new Date(Date.now() + REFRESH_TOKEN_TTL_MS).toISOString();
-        const familyId = crypto.randomUUID();
+        const familyId         = crypto.randomUUID();
 
         await this.repo.storeRefreshToken(userId, sessionId, refreshHash, familyId, refreshExpiresAt);
 

--- a/auth/test/auth-http.test.ts
+++ b/auth/test/auth-http.test.ts
@@ -19,7 +19,7 @@ function resetStore() {
 }
 
 function runSql(sql: string, params?: unknown[]): { rows: unknown[]; rowCount: number } {
-    const s = sql.trim();
+    const s = sql.replace(/\s+/g, ' ').trim();
 
     if (/CREATE TABLE|CREATE INDEX/i.test(s)) {
         return { rows: [], rowCount: 0 };
@@ -32,85 +32,89 @@ function runSql(sql: string, params?: unknown[]): { rows: unknown[]; rowCount: n
         users.push({ id, username, password_hash });
         return { rows: [{ id }], rowCount: 1 };
     }
-    if (/SELECT.*FROM users_credentials WHERE username\s*=/i.test(s)) {
+    if (/SELECT .* FROM users_credentials WHERE username\s*=\s*\$1/i.test(s)) {
         const row = users.find(u => u.username === params![0]) ?? null;
         return { rows: row ? [row] : [], rowCount: row ? 1 : 0 };
     }
-    if (/SELECT.*FROM users_credentials WHERE id\s*=/i.test(s)) {
+    if (/SELECT .* FROM users_credentials WHERE id\s*=\s*\$1/i.test(s)) {
         const row = users.find(u => u.id === params![0]) ?? null;
         return { rows: row ? [row] : [], rowCount: row ? 1 : 0 };
     }
 
-    // ── sessions ─────────────────────────────────────────────────────────────
     if (/INSERT INTO sessions/i.test(s)) {
         const [id, user_id, device_id, device_name] = params as [string, number, string, string?];
         sessions.push({ id, user_id, device_id, device_name, created_at: new Date(), revoked_at: null });
         return { rows: [], rowCount: 1 };
     }
-    if (/COUNT\(\*\).*FROM sessions WHERE user_id/i.test(s)) {
+    if (/SELECT COUNT\(\*\) AS total FROM sessions WHERE user_id\s*=\s*\$1 AND revoked_at IS NULL/i.test(s)) {
         const total = sessions.filter(r => r.user_id === params![0] && !r.revoked_at).length;
         return { rows: [{ total: String(total) }], rowCount: 1 };
     }
-    // SELECT oldest session (revokeOldestActiveSession)
-    if (/SELECT id FROM sessions WHERE user_id.*ORDER BY created_at/is.test(s)) {
+    if (/SELECT id FROM sessions WHERE user_id\s*=\s*\$1 AND revoked_at IS NULL ORDER BY created_at ASC LIMIT 1/i.test(s)) {
         const active = sessions
             .filter(r => r.user_id === params![0] && !r.revoked_at)
             .sort((a, b) => a.created_at.getTime() - b.created_at.getTime());
-        return { rows: active.length ? [{ id: active[0].id }] : [], rowCount: active.length };
+        const oldest = active[0];
+        return { rows: oldest ? [{ id: oldest.id }] : [], rowCount: active.length };
     }
-    // UPDATE sessions WHERE user_id  ← ANTES que WHERE id para evitar colisión
-    if (/UPDATE sessions SET revoked_at.*WHERE user_id/i.test(s)) {
+    if (/UPDATE sessions SET revoked_at = NOW\(\) WHERE user_id\s*=\s*\$1 AND revoked_at IS NULL/i.test(s)) {
         let count = 0;
-        sessions.filter(r => r.user_id === params![0] && !r.revoked_at)
+        sessions
+            .filter(r => r.user_id === params![0] && !r.revoked_at)
             .forEach(r => { r.revoked_at = new Date(); count++; });
         return { rows: [], rowCount: count };
     }
-    // UPDATE sessions WHERE id (revokeOldestActiveSession inner + revokeSessionById)
-    if (/UPDATE sessions SET revoked_at.*WHERE id/i.test(s)) {
+    if (/UPDATE sessions SET revoked_at = NOW\(\) WHERE id\s*=\s*\$1 AND revoked_at IS NULL/i.test(s)) {
         const row = sessions.find(r => r.id === params![0] && !r.revoked_at);
         if (row) row.revoked_at = new Date();
         return { rows: [], rowCount: row ? 1 : 0 };
     }
 
-    // ── refresh_tokens ───────────────────────────────────────────────────────
     if (/INSERT INTO refresh_tokens/i.test(s)) {
         const [user_id, session_id, token_hash, family_id, expires_at] = params as [number, string, string, string, string];
-        tokens.push({ id: ++tokenSeq, user_id, session_id, token_hash, family_id, expires_at, revoked_at: null, created_at: new Date() });
+        tokens.push({
+            id: ++tokenSeq,
+            user_id,
+            session_id,
+            token_hash,
+            family_id,
+            expires_at,
+            revoked_at: null,
+            created_at: new Date()
+        });
         return { rows: [], rowCount: 1 };
     }
-    if (/SELECT.*FROM refresh_tokens WHERE token_hash/i.test(s)) {
+    if (/SELECT id, user_id, session_id, token_hash, family_id, expires_at, revoked_at FROM refresh_tokens WHERE token_hash\s*=\s*\$1/i.test(s)) {
         const row = tokens.find(t => t.token_hash === params![0]) ?? null;
         return { rows: row ? [row] : [], rowCount: row ? 1 : 0 };
     }
-    // UPDATE refresh_tokens WHERE user_id  ← ANTES que WHERE id/session_id
-    if (/UPDATE refresh_tokens SET revoked_at.*WHERE user_id/i.test(s)) {
+    if (/UPDATE refresh_tokens SET revoked_at = NOW\(\) WHERE user_id\s*=\s*\$1 AND revoked_at IS NULL/i.test(s)) {
         let count = 0;
-        tokens.filter(t => t.user_id === params![0] && !t.revoked_at)
+        tokens
+            .filter(t => t.user_id === params![0] && !t.revoked_at)
             .forEach(t => { t.revoked_at = new Date().toISOString(); count++; });
         return { rows: [], rowCount: count };
     }
-    // UPDATE refresh_tokens WHERE family_id
-    if (/UPDATE refresh_tokens SET revoked_at.*WHERE family_id/i.test(s)) {
+    if (/UPDATE refresh_tokens SET revoked_at = NOW\(\) WHERE family_id\s*=\s*\$1 AND revoked_at IS NULL/i.test(s)) {
         let count = 0;
-        tokens.filter(t => t.family_id === params![0] && !t.revoked_at)
+        tokens
+            .filter(t => t.family_id === params![0] && !t.revoked_at)
             .forEach(t => { t.revoked_at = new Date().toISOString(); count++; });
         return { rows: [], rowCount: count };
     }
-    // UPDATE refresh_tokens WHERE session_id
-    if (/UPDATE refresh_tokens SET revoked_at.*WHERE session_id/i.test(s)) {
+    if (/UPDATE refresh_tokens SET revoked_at = NOW\(\) WHERE session_id\s*=\s*\$1 AND revoked_at IS NULL/i.test(s)) {
         let count = 0;
-        tokens.filter(t => t.session_id === params![0] && !t.revoked_at)
+        tokens
+            .filter(t => t.session_id === params![0] && !t.revoked_at)
             .forEach(t => { t.revoked_at = new Date().toISOString(); count++; });
         return { rows: [], rowCount: count };
     }
-    // UPDATE refresh_tokens WHERE id  ← AL FINAL, el más específico corto
-    if (/UPDATE refresh_tokens SET revoked_at.*WHERE id/i.test(s)) {
+    if (/UPDATE refresh_tokens SET revoked_at = NOW\(\) WHERE id\s*=\s*\$1 AND revoked_at IS NULL/i.test(s)) {
         const row = tokens.find(t => t.id === params![0] && !t.revoked_at);
         if (row) row.revoked_at = new Date().toISOString();
         return { rows: [], rowCount: row ? 1 : 0 };
     }
-    // COUNT active tokens (métrica)
-    if (/COUNT\(\*\).*FROM refresh_tokens/i.test(s)) {
+    if (/SELECT COUNT\(\*\) AS total FROM refresh_tokens WHERE revoked_at IS NULL AND expires_at > NOW\(\)/i.test(s)) {
         const total = tokens.filter(t => !t.revoked_at && new Date(t.expires_at) > new Date()).length;
         return { rows: [{ total: String(total) }], rowCount: 1 };
     }

--- a/auth/test/auth-http.test.ts
+++ b/auth/test/auth-http.test.ts
@@ -1,13 +1,167 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 import supertest from 'supertest';
 import jwt from 'jsonwebtoken';
 
 process.env.JWT_SECRET = 'test-secret';
-process.env.AUTH_DB_PATH = '/tmp/asw-auth-http.db';
 
-let request: any;
+interface UserRow    { id: number; username: string; password_hash: string }
+interface SessionRow { id: string; user_id: number; device_id: string; device_name?: string | undefined; created_at: Date; revoked_at: Date | null }
+interface TokenRow   { id: number; user_id: number; session_id: string; token_hash: string; family_id: string; expires_at: string; revoked_at: string | null; created_at: Date }
+
+let users:    UserRow[]    = [];
+let sessions: SessionRow[] = [];
+let tokens:   TokenRow[]   = [];
+let userSeq   = 0;
+let tokenSeq  = 0;
+
+function resetStore() {
+    users = []; sessions = []; tokens = []; userSeq = 0; tokenSeq = 0;
+}
+
+function runSql(sql: string, params?: unknown[]): { rows: unknown[]; rowCount: number } {
+    const s = sql.trim();
+
+    if (/CREATE TABLE|CREATE INDEX/i.test(s)) {
+        return { rows: [], rowCount: 0 };
+    }
+
+    if (/INSERT INTO users_credentials/i.test(s)) {
+        const [username, password_hash] = params as [string, string];
+        if (users.find(u => u.username === username)) throw { code: '23505' };
+        const id = ++userSeq;
+        users.push({ id, username, password_hash });
+        return { rows: [{ id }], rowCount: 1 };
+    }
+    if (/SELECT.*FROM users_credentials WHERE username\s*=/i.test(s)) {
+        const row = users.find(u => u.username === params![0]) ?? null;
+        return { rows: row ? [row] : [], rowCount: row ? 1 : 0 };
+    }
+    if (/SELECT.*FROM users_credentials WHERE id\s*=/i.test(s)) {
+        const row = users.find(u => u.id === params![0]) ?? null;
+        return { rows: row ? [row] : [], rowCount: row ? 1 : 0 };
+    }
+
+    // ── sessions ─────────────────────────────────────────────────────────────
+    if (/INSERT INTO sessions/i.test(s)) {
+        const [id, user_id, device_id, device_name] = params as [string, number, string, string?];
+        sessions.push({ id, user_id, device_id, device_name, created_at: new Date(), revoked_at: null });
+        return { rows: [], rowCount: 1 };
+    }
+    if (/COUNT\(\*\).*FROM sessions WHERE user_id/i.test(s)) {
+        const total = sessions.filter(r => r.user_id === params![0] && !r.revoked_at).length;
+        return { rows: [{ total: String(total) }], rowCount: 1 };
+    }
+    // SELECT oldest session (revokeOldestActiveSession)
+    if (/SELECT id FROM sessions WHERE user_id.*ORDER BY created_at/is.test(s)) {
+        const active = sessions
+            .filter(r => r.user_id === params![0] && !r.revoked_at)
+            .sort((a, b) => a.created_at.getTime() - b.created_at.getTime());
+        return { rows: active.length ? [{ id: active[0].id }] : [], rowCount: active.length };
+    }
+    // UPDATE sessions WHERE user_id  ← ANTES que WHERE id para evitar colisión
+    if (/UPDATE sessions SET revoked_at.*WHERE user_id/i.test(s)) {
+        let count = 0;
+        sessions.filter(r => r.user_id === params![0] && !r.revoked_at)
+            .forEach(r => { r.revoked_at = new Date(); count++; });
+        return { rows: [], rowCount: count };
+    }
+    // UPDATE sessions WHERE id (revokeOldestActiveSession inner + revokeSessionById)
+    if (/UPDATE sessions SET revoked_at.*WHERE id/i.test(s)) {
+        const row = sessions.find(r => r.id === params![0] && !r.revoked_at);
+        if (row) row.revoked_at = new Date();
+        return { rows: [], rowCount: row ? 1 : 0 };
+    }
+
+    // ── refresh_tokens ───────────────────────────────────────────────────────
+    if (/INSERT INTO refresh_tokens/i.test(s)) {
+        const [user_id, session_id, token_hash, family_id, expires_at] = params as [number, string, string, string, string];
+        tokens.push({ id: ++tokenSeq, user_id, session_id, token_hash, family_id, expires_at, revoked_at: null, created_at: new Date() });
+        return { rows: [], rowCount: 1 };
+    }
+    if (/SELECT.*FROM refresh_tokens WHERE token_hash/i.test(s)) {
+        const row = tokens.find(t => t.token_hash === params![0]) ?? null;
+        return { rows: row ? [row] : [], rowCount: row ? 1 : 0 };
+    }
+    // UPDATE refresh_tokens WHERE user_id  ← ANTES que WHERE id/session_id
+    if (/UPDATE refresh_tokens SET revoked_at.*WHERE user_id/i.test(s)) {
+        let count = 0;
+        tokens.filter(t => t.user_id === params![0] && !t.revoked_at)
+            .forEach(t => { t.revoked_at = new Date().toISOString(); count++; });
+        return { rows: [], rowCount: count };
+    }
+    // UPDATE refresh_tokens WHERE family_id
+    if (/UPDATE refresh_tokens SET revoked_at.*WHERE family_id/i.test(s)) {
+        let count = 0;
+        tokens.filter(t => t.family_id === params![0] && !t.revoked_at)
+            .forEach(t => { t.revoked_at = new Date().toISOString(); count++; });
+        return { rows: [], rowCount: count };
+    }
+    // UPDATE refresh_tokens WHERE session_id
+    if (/UPDATE refresh_tokens SET revoked_at.*WHERE session_id/i.test(s)) {
+        let count = 0;
+        tokens.filter(t => t.session_id === params![0] && !t.revoked_at)
+            .forEach(t => { t.revoked_at = new Date().toISOString(); count++; });
+        return { rows: [], rowCount: count };
+    }
+    // UPDATE refresh_tokens WHERE id  ← AL FINAL, el más específico corto
+    if (/UPDATE refresh_tokens SET revoked_at.*WHERE id/i.test(s)) {
+        const row = tokens.find(t => t.id === params![0] && !t.revoked_at);
+        if (row) row.revoked_at = new Date().toISOString();
+        return { rows: [], rowCount: row ? 1 : 0 };
+    }
+    // COUNT active tokens (métrica)
+    if (/COUNT\(\*\).*FROM refresh_tokens/i.test(s)) {
+        const total = tokens.filter(t => !t.revoked_at && new Date(t.expires_at) > new Date()).length;
+        return { rows: [{ total: String(total) }], rowCount: 1 };
+    }
+
+    return { rows: [], rowCount: 0 };
+}
+
+
+
+vi.mock('pg', async () => {
+    class MockClient {
+        private txBuffer: (() => void)[] = [];
+        async connect() { return undefined; }
+        async end()     { return undefined; }
+        async query(sql: string, params?: unknown[]): Promise<{ rows: unknown[]; rowCount: number }> {
+            return runSql(sql, params);
+        }
+    }
+
+    class MockPool {
+        async query(sql: string, params?: unknown[]) { return runSql(sql, params); }
+        async connect() {
+            const client = {
+                query: async (sql: string, params?: unknown[]) => runSql(sql, params),
+                release: vi.fn(),
+                _tx: [] as string[],
+            };
+            // sobreescribir query para manejar BEGIN/COMMIT/ROLLBACK
+            const origQuery = client.query.bind(client);
+            client.query = async (sql: string, params?: unknown[]) => {
+                const s = sql.trim().toUpperCase();
+                if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') {
+                    return { rows: [], rowCount: 0 };
+                }
+                return origQuery(sql, params);
+            };
+            return client;
+        }
+    }
+
+    return { default: { Pool: MockPool, Client: MockClient } };
+});
+
+
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+let request: ReturnType<typeof supertest>;
 
 beforeAll(async () => {
+    resetStore();
     const { app, ensureInitialized } = await import('../src/index.js');
     await ensureInitialized();
     request = supertest(app);
@@ -18,7 +172,6 @@ describe('Auth HTTP contracts', () => {
         const response = await request
             .post('/api/auth/register')
             .send({ username: '', password: '123' });
-
         expect(response.status).toBe(400);
         expect(response.body.error).toBe('invalid_input');
         expect(Array.isArray(response.body.details)).toBe(true);
@@ -28,7 +181,6 @@ describe('Auth HTTP contracts', () => {
         const response = await request
             .post('/api/auth/login')
             .send({ username: 'non-existing-user', password: 'wrong-pass-123' });
-
         expect(response.status).toBe(401);
         expect(response.body.error).toBe('bad_credentials');
     });
@@ -36,61 +188,32 @@ describe('Auth HTTP contracts', () => {
     it('returns 409 user_already_exists on duplicate register', async () => {
         const username = `user-${Date.now()}`;
         const password = 'password123';
-
-        const first = await request
-            .post('/api/auth/register')
-            .send({ username, password });
-
+        const first = await request.post('/api/auth/register').send({ username, password });
         expect(first.status).toBe(201);
-
-        const duplicate = await request
-            .post('/api/auth/register')
-            .send({ username, password });
-
+        const duplicate = await request.post('/api/auth/register').send({ username, password });
         expect(duplicate.status).toBe(409);
         expect(duplicate.body.error).toBe('user_already_exists');
     });
 
     it('returns access and refresh token on register', async () => {
         const username = `session-${Date.now()}`;
-        const password = 'password123';
-
-        const response = await request
-            .post('/api/auth/register')
-            .send({ username, password });
-
+        const response = await request.post('/api/auth/register').send({ username, password: 'password123' });
         expect(response.status).toBe(201);
         expect(response.body.accessToken).toBeTypeOf('string');
         expect(response.body.refreshToken).toBeTypeOf('string');
         expect(response.body.user.username).toBe(username);
-
         const decoded = jwt.decode(response.body.accessToken) as jwt.JwtPayload;
         expect(decoded.tokenType).toBe('access');
     });
 
     it('rotates refresh token on refresh', async () => {
         const username = `rotate-${Date.now()}`;
-        const password = 'password123';
-
-        const register = await request
-            .post('/api/auth/register')
-            .send({ username, password });
-
+        const register = await request.post('/api/auth/register').send({ username, password: 'password123' });
         const refresh1 = register.body.refreshToken;
-
-        const refreshed = await request
-            .post('/api/auth/refresh')
-            .send({ refreshToken: refresh1 });
-
+        const refreshed = await request.post('/api/auth/refresh').send({ refreshToken: refresh1 });
         expect(refreshed.status).toBe(200);
-        expect(refreshed.body.accessToken).toBeTypeOf('string');
-        expect(refreshed.body.refreshToken).toBeTypeOf('string');
         expect(refreshed.body.refreshToken).not.toBe(refresh1);
-
-        const replay = await request
-            .post('/api/auth/refresh')
-            .send({ refreshToken: refresh1 });
-
+        const replay = await request.post('/api/auth/refresh').send({ refreshToken: refresh1 });
         expect(replay.status).toBe(401);
         expect(replay.body.error).toBe('invalid_refresh_token');
     });
@@ -98,76 +221,48 @@ describe('Auth HTTP contracts', () => {
     it('allows login in device A and B, and logout only revokes one session', async () => {
         const username = `devices-${Date.now()}`;
         const password = 'password123';
-
         await request.post('/api/auth/register').send({ username, password, deviceId: 'A' });
-
         const loginA = await request.post('/api/auth/login').send({ username, password, deviceId: 'A' });
         const loginB = await request.post('/api/auth/login').send({ username, password, deviceId: 'B' });
-
         expect(loginA.status).toBe(200);
         expect(loginB.status).toBe(200);
         expect(loginA.body.session.sessionId).not.toBe(loginB.body.session.sessionId);
-
         const logoutA = await request
             .post('/api/auth/logout')
             .set('Authorization', `Bearer ${loginA.body.accessToken}`)
             .send({});
-
         expect(logoutA.status).toBe(204);
-
         const refreshA = await request.post('/api/auth/refresh').send({ refreshToken: loginA.body.refreshToken });
         const refreshB = await request.post('/api/auth/refresh').send({ refreshToken: loginB.body.refreshToken });
-
         expect(refreshA.status).toBe(401);
-        expect(refreshA.body.error).toBe('invalid_refresh_token');
         expect(refreshB.status).toBe(200);
     });
 
     it('logout and logout-all endpoints are idempotent', async () => {
         const username = `logout-${Date.now()}`;
-        const password = 'password123';
-        const login = await request.post('/api/auth/register').send({ username, password, deviceId: 'A' });
-
-        const one = await request
-            .post('/api/auth/logout')
-            .set('Authorization', `Bearer ${login.body.accessToken}`)
-            .send({});
-        const two = await request
-            .post('/api/auth/logout')
-            .set('Authorization', `Bearer ${login.body.accessToken}`)
-            .send({});
-
+        const login = await request.post('/api/auth/register').send({ username, password: 'password123', deviceId: 'A' });
+        const token = login.body.accessToken;
+        const one = await request.post('/api/auth/logout').set('Authorization', `Bearer ${token}`).send({});
+        const two = await request.post('/api/auth/logout').set('Authorization', `Bearer ${token}`).send({});
         expect(one.status).toBe(204);
         expect(two.status).toBe(204);
-
-        const allOne = await request
-            .post('/api/auth/logout-all')
-            .set('Authorization', `Bearer ${login.body.accessToken}`)
-            .send({});
-        const allTwo = await request
-            .post('/api/auth/logout-all')
-            .set('Authorization', `Bearer ${login.body.accessToken}`)
-            .send({});
-
+        const allOne = await request.post('/api/auth/logout-all').set('Authorization', `Bearer ${token}`).send({});
+        const allTwo = await request.post('/api/auth/logout-all').set('Authorization', `Bearer ${token}`).send({});
         expect(allOne.status).toBe(204);
         expect(allTwo.status).toBe(204);
     });
 
     it('keeps at most 3 active sessions per user', async () => {
         const username = `limit-${Date.now()}`;
-        const password = 'password123';
-        await request.post('/api/auth/register').send({ username, password, deviceId: 'D0' });
-
+        await request.post('/api/auth/register').send({ username, password: 'password123', deviceId: 'D0' });
         const sessions = [];
         for (const device of ['D1', 'D2', 'D3', 'D4']) {
-            const login = await request.post('/api/auth/login').send({ username, password, deviceId: device });
+            const login = await request.post('/api/auth/login').send({ username, password: 'password123', deviceId: device });
             expect(login.status).toBe(200);
             sessions.push(login.body);
         }
-
         const refreshOldest = await request.post('/api/auth/refresh').send({ refreshToken: sessions[0].refreshToken });
         const refreshLatest = await request.post('/api/auth/refresh').send({ refreshToken: sessions[3].refreshToken });
-
         expect(refreshOldest.status).toBe(401);
         expect(refreshLatest.status).toBe(200);
     });

--- a/auth/test/auth-service.test.ts
+++ b/auth/test/auth-service.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import bcrypt from 'bcrypt';
 import crypto from 'node:crypto';
+import {randomBytes } from 'node:crypto';
 import jwt from 'jsonwebtoken';
 import { AuthService } from '../src/services/auth.service.js';
 import {
@@ -8,6 +8,29 @@ import {
     InvalidRefreshTokenError,
     UserAlreadyExistsError,
 } from '../src/errors/domain-errors.js';
+
+
+function scryptAsync(
+    password: string,
+    salt: string,
+    keylen: number,
+    options: crypto.ScryptOptions
+): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+        crypto.scrypt(password, salt, keylen, options, (err, derived) => {
+            if (err) reject(err);
+            else resolve(derived);
+        });
+    });
+}
+const SCRYPT_PARAMS = { N: 16384, r: 8, p: 1 };
+const KEY_LEN = 64;
+
+async function hashPasswordForTest(password: string): Promise<string> {
+    const salt = randomBytes(32).toString('hex');
+    const hash = (await scryptAsync(password, salt, KEY_LEN, SCRYPT_PARAMS)) as Buffer;
+    return `${salt}:${hash.toString('hex')}`;
+}
 
 type MockRepo = {
     createUser: ReturnType<typeof vi.fn>;
@@ -58,14 +81,15 @@ describe('AuthService', () => {
         expect(result.refreshToken).toBeTypeOf('string');
         expect(repo.createUser).toHaveBeenCalledTimes(1);
 
+        // Verifica que el hash almacenado tiene formato salt:hex (scrypt)
         const [, storedHash] = repo.createUser.mock.calls.at(0)!;
         expect(storedHash).not.toBe('password123');
-        expect(await bcrypt.compare('password123', storedHash)).toBe(true);
+        expect(storedHash).toMatch(/^[a-f0-9]{64}:[a-f0-9]{128}$/);
     });
 
-    it('register_user_exists throws UserAlreadyExistsError', async () => {
+    it('register_user_exists throws UserAlreadyExistsError on PG unique constraint (23505)', async () => {
         const repo = buildRepoMock();
-        repo.createUser.mockRejectedValue({ code: 'SQLITE_CONSTRAINT' });
+        repo.createUser.mockRejectedValue({ code: '23505' });
 
         const service = new AuthService(repo as any);
 
@@ -74,12 +98,12 @@ describe('AuthService', () => {
         );
     });
 
-    it('login_ok returns access token', async () => {
+    it('login_ok returns access token with scrypt-hashed password', async () => {
         const repo = buildRepoMock();
         repo.findUserByUsername.mockResolvedValue({
             id: 4,
             username: 'bob',
-            password_hash: await bcrypt.hash('password123', 4),
+            password_hash: await hashPasswordForTest('password123'),
         });
 
         const service = new AuthService(repo as any);
@@ -90,7 +114,22 @@ describe('AuthService', () => {
         expect(result.refreshToken).toBeTypeOf('string');
     });
 
-    it('login_bad_credentials throws BadCredentialsError', async () => {
+    it('login_wrong_password throws BadCredentialsError', async () => {
+        const repo = buildRepoMock();
+        repo.findUserByUsername.mockResolvedValue({
+            id: 4,
+            username: 'bob',
+            password_hash: await hashPasswordForTest('password123'),
+        });
+
+        const service = new AuthService(repo as any);
+
+        await expect(service.login('bob', 'wrongpassword')).rejects.toBeInstanceOf(
+            BadCredentialsError
+        );
+    });
+
+    it('login_bad_credentials throws BadCredentialsError when user not found', async () => {
         const repo = buildRepoMock();
         repo.findUserByUsername.mockResolvedValue(null);
 
@@ -101,19 +140,33 @@ describe('AuthService', () => {
         );
     });
 
+    it('login_revokes_oldest_session when active sessions >= 3', async () => {
+        const repo = buildRepoMock();
+        repo.findUserByUsername.mockResolvedValue({
+            id: 5,
+            username: 'charlie',
+            password_hash: await hashPasswordForTest('password123'),
+        });
+        repo.countActiveSessions.mockResolvedValue(3);
+        repo.revokeOldestActiveSession.mockResolvedValue(1);
+
+        const service = new AuthService(repo as any);
+        await service.login('charlie', 'password123');
+
+        expect(repo.revokeOldestActiveSession).toHaveBeenCalledWith(5);
+    });
+
     it('refresh_ok rotates refresh token and returns new tokens', async () => {
         const repo = buildRepoMock();
         const oldToken = 'old-refresh-token';
         const oldHash = crypto.createHash('sha256').update(oldToken).digest('hex');
         repo.findUserById.mockResolvedValue({ id: 9, username: 'testuser' });
         repo.findRefreshTokenByHash.mockImplementation(async (tokenHash: string) => {
-            if (tokenHash !== oldHash) {
-                return null;
-            }
-
+            if (tokenHash !== oldHash) return null;
             return {
                 id: 15,
                 user_id: 9,
+                session_id: 'sess-x',
                 token_hash: oldHash,
                 family_id: 'family-1',
                 expires_at: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
@@ -136,44 +189,56 @@ describe('AuthService', () => {
         expect(storedFamilyId).toBe('family-1');
     });
 
-    it('refresh_invalid_or_expired_or_revoked returns InvalidRefreshTokenError', async () => {
+    it('refresh_missing_token throws InvalidRefreshTokenError', async () => {
         const repo = buildRepoMock();
         const service = new AuthService(repo as any);
+        await expect(service.refresh(undefined)).rejects.toBeInstanceOf(InvalidRefreshTokenError);
+    });
 
-        await expect(service.refresh('missing-token')).rejects.toBeInstanceOf(
-            InvalidRefreshTokenError
-        );
+    it('refresh_token_not_found throws InvalidRefreshTokenError', async () => {
+        const repo = buildRepoMock();
+        repo.findRefreshTokenByHash.mockResolvedValue(null);
+        const service = new AuthService(repo as any);
+        await expect(service.refresh('nonexistent-token')).rejects.toBeInstanceOf(InvalidRefreshTokenError);
+    });
 
+    it('refresh_revoked_token revokes family and throws InvalidRefreshTokenError', async () => {
+        const repo = buildRepoMock();
         const revokedToken = 'revoked-token';
         const revokedHash = crypto.createHash('sha256').update(revokedToken).digest('hex');
-        repo.findRefreshTokenByHash.mockResolvedValueOnce({
+        repo.findRefreshTokenByHash.mockResolvedValue({
             id: 20,
             user_id: 2,
+            session_id: 'sess-r',
             token_hash: revokedHash,
             family_id: 'family-r',
             expires_at: new Date(Date.now() + 60_000).toISOString(),
             revoked_at: new Date().toISOString(),
         });
+        repo.revokeRefreshTokenFamily.mockResolvedValue(2);
 
-        await expect(service.refresh(revokedToken)).rejects.toBeInstanceOf(
-            InvalidRefreshTokenError
-        );
+        const service = new AuthService(repo as any);
+        await expect(service.refresh(revokedToken)).rejects.toBeInstanceOf(InvalidRefreshTokenError);
         expect(repo.revokeRefreshTokenFamily).toHaveBeenCalledWith('family-r');
+    });
 
+    it('refresh_expired_token revokes token and throws InvalidRefreshTokenError', async () => {
+        const repo = buildRepoMock();
         const expiredToken = 'expired-token';
         const expiredHash = crypto.createHash('sha256').update(expiredToken).digest('hex');
-        repo.findRefreshTokenByHash.mockResolvedValueOnce({
+        repo.findRefreshTokenByHash.mockResolvedValue({
             id: 21,
             user_id: 2,
+            session_id: 'sess-e',
             token_hash: expiredHash,
             family_id: 'family-e',
             expires_at: new Date(Date.now() - 60_000).toISOString(),
             revoked_at: null,
         });
+        repo.revokeRefreshToken.mockResolvedValue(1);
 
-        await expect(service.refresh(expiredToken)).rejects.toBeInstanceOf(
-            InvalidRefreshTokenError
-        );
+        const service = new AuthService(repo as any);
+        await expect(service.refresh(expiredToken)).rejects.toBeInstanceOf(InvalidRefreshTokenError);
         expect(repo.revokeRefreshToken).toHaveBeenCalledWith(21);
     });
 
@@ -187,5 +252,28 @@ describe('AuthService', () => {
         const decoded = jwt.decode(result.accessToken) as jwt.JwtPayload | null;
         expect(decoded).not.toBeNull();
         expect(decoded!.tokenType).toBe('access');
+    });
+
+    it('logout calls revokeSessionById', async () => {
+        const repo = buildRepoMock();
+        repo.revokeSessionById.mockResolvedValue(1);
+        const service = new AuthService(repo as any);
+        await service.logout('sess-abc');
+        expect(repo.revokeSessionById).toHaveBeenCalledWith('sess-abc');
+    });
+
+    it('logout without sessionId does nothing', async () => {
+        const repo = buildRepoMock();
+        const service = new AuthService(repo as any);
+        await service.logout(undefined);
+        expect(repo.revokeSessionById).not.toHaveBeenCalled();
+    });
+
+    it('logoutAll calls revokeAllUserSessions', async () => {
+        const repo = buildRepoMock();
+        repo.revokeAllUserSessions.mockResolvedValue(2);
+        const service = new AuthService(repo as any);
+        await service.logoutAll(42);
+        expect(repo.revokeAllUserSessions).toHaveBeenCalledWith(42);
     });
 });

--- a/auth/test/bootstrap-index-verify.test.ts
+++ b/auth/test/bootstrap-index-verify.test.ts
@@ -2,6 +2,31 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import path from 'node:path';
 import supertest from 'supertest';
 
+vi.mock('pg', async () => {
+    class MockClient {
+        async connect() { return undefined; }
+        async end()     { return undefined; }
+        async query()   { return { rows: [], rowCount: 0 }; }
+    }
+    class MockPool {
+        async query(sql: string) {
+            if (/CREATE TABLE|CREATE INDEX/i.test(sql)) return { rows: [], rowCount: 0 };
+            return { rows: [], rowCount: 0 };
+        }
+        async connect() {
+            return {
+                query: async (sql: string) => {
+                    const s = sql.trim().toUpperCase();
+                    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') return { rows: [], rowCount: 0 };
+                    return { rows: [], rowCount: 0 };
+                },
+                release: vi.fn(),
+            };
+        }
+    }
+    return { default: { Pool: MockPool, Client: MockClient } };
+});
+
 const indexPath = path.resolve(process.cwd(), 'src/index.ts');
 
 describe('bootstrap/index/verify coverage', () => {
@@ -9,14 +34,10 @@ describe('bootstrap/index/verify coverage', () => {
         vi.resetModules();
         vi.restoreAllMocks();
         delete process.env.JWT_SECRET;
-        delete process.env.AUTH_DB_PATH;
     });
 
-    it('getAuthDbPath default and getAuthService before init', async () => {
+    it('getAuthService throws before init', async () => {
         const context = await import('../src/bootstrap/auth-context.js');
-        expect(context.getAuthDbPath()).toBe('/app/auth/data/auth.db');
-        process.env.AUTH_DB_PATH = ' /tmp/auth-custom.db ';
-        expect(context.getAuthDbPath()).toBe('/tmp/auth-custom.db');
         expect(() => context.getAuthService()).toThrow('Auth context is not initialized');
     });
 
@@ -35,7 +56,6 @@ describe('bootstrap/index/verify coverage', () => {
 
     it('startServer listens when initialized', async () => {
         process.env.JWT_SECRET = 'ok-secret';
-        process.env.AUTH_DB_PATH = `/tmp/asw-auth-index-${Date.now()}.db`;
 
         const { app, startServer } = await import('../src/index.js');
         const listenSpy = vi.spyOn(app, 'listen').mockImplementation(((_port: any, cb?: any) => {
@@ -52,7 +72,7 @@ describe('bootstrap/index/verify coverage', () => {
 
     it('direct run path handles startup failures', async () => {
         const previousArgv = [...process.argv];
-        const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as any);
+        const exitSpy  = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as any);
         const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
         process.argv[1] = indexPath;

--- a/auth/test/credentials.repository.test.ts
+++ b/auth/test/credentials.repository.test.ts
@@ -1,325 +1,305 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { CredentialsRepository } from '../src/repositories/credentials.repository.js';
-import sqlite3 from 'sqlite3';
 
-const SCHEMA = `
-CREATE TABLE IF NOT EXISTS users_credentials (
-    id            INTEGER PRIMARY KEY AUTOINCREMENT,
-    username      TEXT    NOT NULL UNIQUE,
-    password_hash TEXT    NOT NULL
-);
-CREATE TABLE IF NOT EXISTS sessions (
-    id         TEXT    PRIMARY KEY,
-    user_id    INTEGER NOT NULL,
-    device_id  TEXT    NOT NULL,
-    device_name TEXT,
-    created_at TEXT    NOT NULL DEFAULT (datetime('now')),
-    revoked_at TEXT
-);
-CREATE TABLE IF NOT EXISTS refresh_tokens (
-    id         INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id    INTEGER NOT NULL,
-    session_id TEXT    NOT NULL,
-    token_hash TEXT    NOT NULL,
-    family_id  TEXT    NOT NULL,
-    expires_at TEXT    NOT NULL,
-    revoked_at TEXT
-);
-`;
-
-function buildInMemoryRepo(): { repo: CredentialsRepository; db: sqlite3.Database } {
-    const db = new sqlite3.Database(':memory:');
-    (db as any).serialize(() => {
-        SCHEMA.split(';').filter(s => s.trim()).forEach(stmt => db.run(stmt + ';'));
-    });
-    const repo = new CredentialsRepository(':memory:');
-    (repo as any).db = db;
-    return { repo, db };
+type Row = Record<string, unknown>;
+interface FakeQueryResult {
+    rows: Row[];
+    rowCount: number;
 }
 
-function buildBrokenRepo(): CredentialsRepository {
-    const repo = new CredentialsRepository(':memory:');
-    const fakeDb = {
-        run: (_sql: string, _params: any, cb: Function) => cb(new Error('db error')),
-        get: (_sql: string, _params: any, cb: Function) => cb(new Error('db error')),
-        serialize: (fn: Function) => fn(),
+
+const mockQuery   = vi.fn();
+const mockConnect = vi.fn();
+const mockRelease = vi.fn();
+
+vi.mock('pg', async () => {
+    class MockPool {
+        query   = mockQuery;
+        connect = mockConnect;
+        constructor(_config?: unknown) {}
+    }
+    return {
+
+        default: { Pool: MockPool },
     };
-    (repo as any).db = fakeDb;
-    return repo;
+});
+
+function makeClient(queryImpl: (sql: string) => FakeQueryResult | Promise<FakeQueryResult>) {
+    const client = {
+        query: vi.fn().mockImplementation((sql: string) => Promise.resolve(queryImpl(sql))),
+        release: mockRelease,
+    };
+    mockConnect.mockResolvedValue(client);
+    return client;
 }
 
 
 describe('CredentialsRepository – happy path', () => {
     let repo: CredentialsRepository;
-    let db: sqlite3.Database;
 
     beforeEach(() => {
-        ({ repo, db } = buildInMemoryRepo());
+        vi.clearAllMocks();
+        repo = new CredentialsRepository();
     });
 
-    afterEach(() => new Promise<void>((resolve, reject) => {
-        db.close(err => err ? reject(err) : resolve());
-    }));
-
-    it('createUser returns a numeric id', async () => {
+    it('createUser returns the id from RETURNING clause', async () => {
+        mockQuery.mockResolvedValue({ rows: [{ id: 42 }], rowCount: 1 });
         const id = await repo.createUser('alice', 'hash1');
-        expect(typeof id).toBe('number');
-        expect(id).toBeGreaterThan(0);
+        expect(id).toBe(42);
+        expect(mockQuery).toHaveBeenCalledWith(
+            expect.stringContaining('INSERT INTO users_credentials'),
+            ['alice', 'hash1']
+        );
     });
 
-    it('findUserByUsername returns the created user', async () => {
-        await repo.createUser('alice', 'hash1');
+    it('findUserByUsername returns the user row', async () => {
+        mockQuery.mockResolvedValue({
+            rows: [{ id: 1, username: 'alice', password_hash: 'hash1' }],
+            rowCount: 1,
+        });
         const user = await repo.findUserByUsername('alice');
         expect(user).not.toBeNull();
         expect(user!.username).toBe('alice');
-        expect(user!.password_hash).toBe('hash1');
     });
 
-    it('findUserByUsername returns null for unknown user', async () => {
+    it('findUserByUsername returns null when not found', async () => {
+        mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
         const user = await repo.findUserByUsername('nobody');
         expect(user).toBeNull();
     });
 
-    it('findUserById returns the created user', async () => {
-        const id = await repo.createUser('bob', 'hash2');
-        const user = await repo.findUserById(id);
+    it('findUserById returns the user row', async () => {
+        mockQuery.mockResolvedValue({
+            rows: [{ id: 7, username: 'bob' }],
+            rowCount: 1,
+        });
+        const user = await repo.findUserById(7);
         expect(user).not.toBeNull();
-        expect(user!.id).toBe(id);
-        expect(user!.username).toBe('bob');
+        expect(user!.id).toBe(7);
     });
 
-    it('findUserById returns null for unknown id', async () => {
+    it('findUserById returns null when not found', async () => {
+        mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
         const user = await repo.findUserById(9999);
         expect(user).toBeNull();
     });
 
-    it('createSession then countActiveSessions returns 1', async () => {
-        const uid = await repo.createUser('carol', 'hash3');
-        await repo.createSession('sess-1', uid, 'dev-1', 'My Phone');
-        const count = await repo.countActiveSessions(uid);
-        expect(count).toBe(1);
+    it('createSession resolves without error', async () => {
+        mockQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+        await expect(repo.createSession('sess-1', 1, 'dev-1', 'My Phone')).resolves.toBeUndefined();
     });
 
-    it('countActiveSessions returns 0 for new user', async () => {
-        const uid = await repo.createUser('dave', 'hash4');
-        const count = await repo.countActiveSessions(uid);
+    it('countActiveSessions returns the count', async () => {
+        mockQuery.mockResolvedValue({ rows: [{ total: '3' }], rowCount: 1 });
+        const count = await repo.countActiveSessions(1);
+        expect(count).toBe(3);
+    });
+
+    it('countActiveSessions returns 0 when no rows', async () => {
+        mockQuery.mockResolvedValue({ rows: [{ total: null }], rowCount: 1 });
+        const count = await repo.countActiveSessions(99);
         expect(count).toBe(0);
     });
 
-    it('storeRefreshToken then findRefreshTokenByHash returns the record', async () => {
-        const uid = await repo.createUser('eve', 'hash5');
-        await repo.createSession('sess-2', uid, 'dev-2');
-        const expiresAt = new Date(Date.now() + 60_000).toISOString();
-        await repo.storeRefreshToken(uid, 'sess-2', 'hash-abc', 'fam-1', expiresAt);
-        const record = await repo.findRefreshTokenByHash('hash-abc');
-        expect(record).not.toBeNull();
-        expect(record!.user_id).toBe(uid);
-        expect(record!.family_id).toBe('fam-1');
-        expect(record!.revoked_at).toBeNull();
+    it('storeRefreshToken resolves without error', async () => {
+        mockQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+        await expect(
+            repo.storeRefreshToken(1, 'sess-1', 'hash-abc', 'fam-1', new Date().toISOString())
+        ).resolves.toBeUndefined();
     });
 
-    it('findRefreshTokenByHash returns null for unknown hash', async () => {
-        const record = await repo.findRefreshTokenByHash('nonexistent');
-        expect(record).toBeNull();
+    it('findRefreshTokenByHash returns the token record', async () => {
+        const record = {
+            id: 5,
+            user_id: 1,
+            session_id: 'sess-1',
+            token_hash: 'hash-abc',
+            family_id: 'fam-1',
+            expires_at: new Date().toISOString(),
+            revoked_at: null,
+        };
+        mockQuery.mockResolvedValue({ rows: [record], rowCount: 1 });
+        const result = await repo.findRefreshTokenByHash('hash-abc');
+        expect(result).toEqual(record);
     });
 
-    it('revokeRefreshToken sets revoked_at and returns 1', async () => {
-        const uid = await repo.createUser('frank', 'hash6');
-        await repo.createSession('sess-3', uid, 'dev-3');
-        const expiresAt = new Date(Date.now() + 60_000).toISOString();
-        await repo.storeRefreshToken(uid, 'sess-3', 'hash-def', 'fam-2', expiresAt);
-        const record = await repo.findRefreshTokenByHash('hash-def');
-        const changes = await repo.revokeRefreshToken(record!.id);
+    it('findRefreshTokenByHash returns null when not found', async () => {
+        mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+        const result = await repo.findRefreshTokenByHash('nonexistent');
+        expect(result).toBeNull();
+    });
+
+    it('revokeRefreshToken returns rowCount', async () => {
+        mockQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+        const changes = await repo.revokeRefreshToken(5);
         expect(changes).toBe(1);
-        const after = await repo.findRefreshTokenByHash('hash-def');
-        expect(after!.revoked_at).not.toBeNull();
     });
 
     it('revokeRefreshToken returns 0 for already-revoked token', async () => {
-        const uid = await repo.createUser('frank2', 'hash6b');
-        await repo.createSession('sess-3b', uid, 'dev-3b');
-        const expiresAt = new Date(Date.now() + 60_000).toISOString();
-        await repo.storeRefreshToken(uid, 'sess-3b', 'hash-defb', 'fam-2b', expiresAt);
-        const record = await repo.findRefreshTokenByHash('hash-defb');
-        await repo.revokeRefreshToken(record!.id);
-        const changes = await repo.revokeRefreshToken(record!.id);
+        mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+        const changes = await repo.revokeRefreshToken(5);
         expect(changes).toBe(0);
     });
 
-    it('revokeRefreshTokenFamily revokes all tokens in the family', async () => {
-        const uid = await repo.createUser('grace', 'hash7');
-        await repo.createSession('sess-4', uid, 'dev-4');
-        const expiresAt = new Date(Date.now() + 60_000).toISOString();
-        await repo.storeRefreshToken(uid, 'sess-4', 'hash-1', 'fam-3', expiresAt);
-        await repo.storeRefreshToken(uid, 'sess-4', 'hash-2', 'fam-3', expiresAt);
-        const changes = await repo.revokeRefreshTokenFamily('fam-3');
+    it('revokeRefreshTokenFamily returns rowCount', async () => {
+        mockQuery.mockResolvedValue({ rows: [], rowCount: 2 });
+        const changes = await repo.revokeRefreshTokenFamily('fam-1');
         expect(changes).toBe(2);
     });
 
-    it('revokeAllUserSessions revokes sessions and tokens', async () => {
-        const uid = await repo.createUser('henry', 'hash8');
-        await repo.createSession('sess-5', uid, 'dev-5');
-        const expiresAt = new Date(Date.now() + 60_000).toISOString();
-        await repo.storeRefreshToken(uid, 'sess-5', 'hash-xxx', 'fam-4', expiresAt);
-        await repo.revokeAllUserSessions(uid);
-        const count = await repo.countActiveSessions(uid);
-        expect(count).toBe(0);
+    it('revokeRefreshTokenFamily returns 0 for unknown family', async () => {
+        mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+        const changes = await repo.revokeRefreshTokenFamily('unknown-family');
+        expect(changes).toBe(0);
     });
 
-    it('revokeSessionById revokes only the target session', async () => {
-        const uid = await repo.createUser('ivan', 'hash9');
-        await repo.createSession('sess-6', uid, 'dev-6');
-        await repo.createSession('sess-7', uid, 'dev-7');
-        const expiresAt = new Date(Date.now() + 60_000).toISOString();
-        await repo.storeRefreshToken(uid, 'sess-6', 'hash-yyy', 'fam-5', expiresAt);
-        await repo.revokeSessionById('sess-6');
-        const count = await repo.countActiveSessions(uid);
-        expect(count).toBe(1);
+    it('revokeAllUserSessions commits transaction and returns rowCount', async () => {
+        const client = makeClient(() => ({ rows: [], rowCount: 1 }));
+        const changes = await repo.revokeAllUserSessions(1);
+        expect(client.query).toHaveBeenCalledWith('BEGIN');
+        expect(client.query).toHaveBeenCalledWith('COMMIT');
+        expect(mockRelease).toHaveBeenCalled();
+        expect(changes).toBe(1);
     });
 
-    it('revokeOldestActiveSession revokes the oldest session', async () => {
-        const uid = await repo.createUser('judy', 'hash10');
-        await repo.createSession('sess-old', uid, 'dev-old');
-        await repo.createSession('sess-new', uid, 'dev-new');
-        const expiresAt = new Date(Date.now() + 60_000).toISOString();
-        await repo.storeRefreshToken(uid, 'sess-old', 'hash-old', 'fam-old', expiresAt);
-        await repo.revokeOldestActiveSession(uid);
-        const count = await repo.countActiveSessions(uid);
-        expect(count).toBe(1);
+    it('revokeSessionById commits transaction and returns rowCount', async () => {
+        const client = makeClient(() => ({ rows: [], rowCount: 1 }));
+        const changes = await repo.revokeSessionById('sess-1');
+        expect(client.query).toHaveBeenCalledWith('BEGIN');
+        expect(client.query).toHaveBeenCalledWith('COMMIT');
+        expect(mockRelease).toHaveBeenCalled();
+        expect(changes).toBe(1);
     });
 
     it('revokeOldestActiveSession returns 0 when no active sessions', async () => {
-        const uid = await repo.createUser('kate', 'hash11');
-        const changes = await repo.revokeOldestActiveSession(uid);
+        const client = makeClient((sql) => {
+            if (sql.includes('SELECT')) return { rows: [], rowCount: 0 };
+            return { rows: [], rowCount: 0 };
+        });
+        const changes = await repo.revokeOldestActiveSession(1);
         expect(changes).toBe(0);
+        expect(client.query).toHaveBeenCalledWith('COMMIT');
+        expect(mockRelease).toHaveBeenCalled();
     });
 
-    it('countActiveRefreshTokens does not count expired tokens', async () => {
-        const uid = await repo.createUser('leo', 'hash12');
-        await repo.createSession('sess-8', uid, 'dev-8');
-        const future = new Date(Date.now() + 60_000).toISOString();
-        const past   = new Date(Date.now() - 60_000).toISOString();
-        await repo.storeRefreshToken(uid, 'sess-8', 'hash-active',  'fam-6', future);
-        await repo.storeRefreshToken(uid, 'sess-8', 'hash-expired', 'fam-7', past);
+    it('revokeOldestActiveSession revokes session and tokens', async () => {
+        let callCount = 0;
+        const client = makeClient((sql) => {
+            callCount++;
+            if (sql.includes('SELECT')) return { rows: [{ id: 'sess-old' }], rowCount: 1 };
+            return { rows: [], rowCount: 1 };
+        });
+        const changes = await repo.revokeOldestActiveSession(1);
+        expect(changes).toBe(1);
+        expect(client.query).toHaveBeenCalledWith('COMMIT');
+        expect(mockRelease).toHaveBeenCalled();
+    });
+
+    it('countActiveRefreshTokens returns count of non-expired non-revoked tokens', async () => {
+        mockQuery.mockResolvedValue({ rows: [{ total: '4' }], rowCount: 1 });
         const count = await repo.countActiveRefreshTokens();
-        expect(count).toBeGreaterThanOrEqual(1);
-    });
-    it('revokeOldestActiveSession returns 0 when no active sessions remain', async () => {
-        const uid = await repo.createUser('mary', 'hashM');
-        await repo.createSession('sess-revoked', uid, 'dev-m');
-        await repo.revokeSessionById('sess-revoked');
-        const changes = await repo.revokeOldestActiveSession(uid);
-        expect(changes).toBe(0);
-    });
-
-    it('findRefreshTokenByHash returns null for unknown hash', async () => {
-        const record = await repo.findRefreshTokenByHash('nonexistent-hash');
-        expect(record).toBeNull();
-    });
-
-    it('revokeRefreshTokenFamily returns 0 for unknown family', async () => {
-        const changes = await repo.revokeRefreshTokenFamily('unknown-family-id');
-        expect(changes).toBe(0);
-    });
-
-    it('revokeSessionById returns 0 for unknown session', async () => {
-        const uid = await repo.createUser('nora', 'hashO');
-        await repo.createSession('sess-nora', uid, 'dev-o');
-        const changes = await repo.revokeSessionById('nonexistent-session');
-        expect(changes).toBe(0);
-    });
-
-    it('createUser with duplicate username rejects', async () => {
-        await repo.createUser('dupuser', 'hashD');
-        await expect(repo.createUser('dupuser', 'hashD2')).rejects.toThrow();
-    });
-
-    it('storeRefreshToken allows multiple tokens per session', async () => {
-        const uid = await repo.createUser('multi', 'hashMM');
-        await repo.createSession('sess-multi', uid, 'dev-mm');
-        const expiresAt = new Date(Date.now() + 60_000).toISOString();
-        await repo.storeRefreshToken(uid, 'sess-multi', 'hash-t1', 'fam-mm', expiresAt);
-        await repo.storeRefreshToken(uid, 'sess-multi', 'hash-t2', 'fam-mm', expiresAt);
-        const t1 = await repo.findRefreshTokenByHash('hash-t1');
-        const t2 = await repo.findRefreshTokenByHash('hash-t2');
-        expect(t1).not.toBeNull();
-        expect(t2).not.toBeNull();
-    });
-
-    it('countActiveRefreshTokens returns 0 on fresh db', async () => {
-        const count = await repo.countActiveRefreshTokens();
-        expect(count).toBeGreaterThanOrEqual(0);
+        expect(count).toBe(4);
     });
 });
 
-
+// ── Suite: error paths ─────────────────────────────────────────────────────────
 
 describe('CredentialsRepository – DB error paths', () => {
+    let repo: CredentialsRepository;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        repo = new CredentialsRepository();
+    });
+
     it('createUser rejects on DB error', async () => {
-        const repo = buildBrokenRepo();
+        mockQuery.mockRejectedValue(new Error('db error'));
         await expect(repo.createUser('x', 'h')).rejects.toThrow('db error');
     });
 
     it('findUserByUsername rejects on DB error', async () => {
-        const repo = buildBrokenRepo();
+        mockQuery.mockRejectedValue(new Error('db error'));
         await expect(repo.findUserByUsername('x')).rejects.toThrow('db error');
     });
 
     it('findUserById rejects on DB error', async () => {
-        const repo = buildBrokenRepo();
+        mockQuery.mockRejectedValue(new Error('db error'));
         await expect(repo.findUserById(1)).rejects.toThrow('db error');
     });
 
     it('createSession rejects on DB error', async () => {
-        const repo = buildBrokenRepo();
+        mockQuery.mockRejectedValue(new Error('db error'));
         await expect(repo.createSession('s', 1, 'd')).rejects.toThrow('db error');
     });
 
     it('countActiveSessions rejects on DB error', async () => {
-        const repo = buildBrokenRepo();
+        mockQuery.mockRejectedValue(new Error('db error'));
         await expect(repo.countActiveSessions(1)).rejects.toThrow('db error');
     });
 
     it('storeRefreshToken rejects on DB error', async () => {
-        const repo = buildBrokenRepo();
+        mockQuery.mockRejectedValue(new Error('db error'));
         await expect(
             repo.storeRefreshToken(1, 's', 'h', 'f', new Date().toISOString())
         ).rejects.toThrow('db error');
     });
 
     it('findRefreshTokenByHash rejects on DB error', async () => {
-        const repo = buildBrokenRepo();
+        mockQuery.mockRejectedValue(new Error('db error'));
         await expect(repo.findRefreshTokenByHash('h')).rejects.toThrow('db error');
     });
 
     it('revokeRefreshToken rejects on DB error', async () => {
-        const repo = buildBrokenRepo();
+        mockQuery.mockRejectedValue(new Error('db error'));
         await expect(repo.revokeRefreshToken(1)).rejects.toThrow('db error');
     });
 
     it('revokeRefreshTokenFamily rejects on DB error', async () => {
-        const repo = buildBrokenRepo();
+        mockQuery.mockRejectedValue(new Error('db error'));
         await expect(repo.revokeRefreshTokenFamily('f')).rejects.toThrow('db error');
     });
 
-    it('revokeAllUserSessions rejects on DB error', async () => {
-        const repo = buildBrokenRepo();
+    it('revokeAllUserSessions rolls back and rethrows on DB error', async () => {
+        const client = {
+            query: vi.fn()
+                .mockResolvedValueOnce(undefined)           // BEGIN
+                .mockRejectedValueOnce(new Error('db error')), // UPDATE sessions
+            release: mockRelease,
+        };
+        mockConnect.mockResolvedValue(client);
         await expect(repo.revokeAllUserSessions(1)).rejects.toThrow('db error');
+        expect(client.query).toHaveBeenCalledWith('ROLLBACK');
+        expect(mockRelease).toHaveBeenCalled();
     });
 
-    it('revokeSessionById rejects on DB error', async () => {
-        const repo = buildBrokenRepo();
+    it('revokeSessionById rolls back and rethrows on DB error', async () => {
+        const client = {
+            query: vi.fn()
+                .mockResolvedValueOnce(undefined)           // BEGIN
+                .mockRejectedValueOnce(new Error('db error')), // UPDATE sessions
+            release: mockRelease,
+        };
+        mockConnect.mockResolvedValue(client);
         await expect(repo.revokeSessionById('s')).rejects.toThrow('db error');
+        expect(client.query).toHaveBeenCalledWith('ROLLBACK');
+        expect(mockRelease).toHaveBeenCalled();
+    });
+
+    it('revokeOldestActiveSession rolls back and rethrows on DB error', async () => {
+        const client = {
+            query: vi.fn()
+                .mockResolvedValueOnce(undefined)           // BEGIN
+                .mockRejectedValueOnce(new Error('db error')), // SELECT
+            release: mockRelease,
+        };
+        mockConnect.mockResolvedValue(client);
+        await expect(repo.revokeOldestActiveSession(1)).rejects.toThrow('db error');
+        expect(client.query).toHaveBeenCalledWith('ROLLBACK');
+        expect(mockRelease).toHaveBeenCalled();
     });
 
     it('countActiveRefreshTokens rejects on DB error', async () => {
-        const repo = buildBrokenRepo();
+        mockQuery.mockRejectedValue(new Error('db error'));
         await expect(repo.countActiveRefreshTokens()).rejects.toThrow('db error');
     });
-
-    it('revokeOldestActiveSession rejects on DB error', async () => {
-        const repo = buildBrokenRepo();
-        await expect(repo.revokeOldestActiveSession(1)).rejects.toThrow('db error');
-    });
-
 });

--- a/auth/test/credentials.repository.test.ts
+++ b/auth/test/credentials.repository.test.ts
@@ -7,20 +7,22 @@ interface FakeQueryResult {
     rowCount: number;
 }
 
-
-const mockQuery   = vi.fn();
-const mockConnect = vi.fn();
 const mockRelease = vi.fn();
 
+const { mockQuery, mockConnect } = vi.hoisted(() => ({
+    mockQuery: vi.fn(),
+    mockConnect: vi.fn(),
+}));
 vi.mock('pg', async () => {
     class MockPool {
-        query   = mockQuery;
+        query = mockQuery;
         connect = mockConnect;
         constructor(_config?: unknown) {}
     }
-    return {
 
+    return {
         default: { Pool: MockPool },
+        Pool: MockPool,
     };
 });
 

--- a/auth/test/extra-coverage.test.ts
+++ b/auth/test/extra-coverage.test.ts
@@ -25,19 +25,19 @@ describe('extra coverage', () => {
         expect(json).toHaveBeenCalledWith({ ok: true });
     });
 
-    it('initAuthDatabase surfaces sqlite open errors', async () => {
-        vi.doMock('sqlite3', () => ({
+    it('initAuthDatabase surfaces pg connection errors', async () => {
+        vi.doMock('pg', () => ({
             default: {
-                Database: class {
-                    constructor(_path: string, callback: (err: Error) => void) {
-                        callback(new Error('open-failed'));
-                    }
+                Client: class {
+                    connect() { return Promise.reject(new Error('pg-connect-failed')); }
+                    end()     { return Promise.resolve(); }
+                    query()   { return Promise.resolve({ rows: [] }); }
                 },
             },
         }));
 
         const { initAuthDatabase } = await import('../src/db/init-auth-db.js');
-        await expect(initAuthDatabase('/tmp/whatever.db')).rejects.toThrow('open-failed');
+        await expect(initAuthDatabase()).rejects.toThrow('pg-connect-failed');
     });
 
     it('ensureInitialized caches initialization promise', async () => {
@@ -46,7 +46,7 @@ describe('extra coverage', () => {
         }));
 
         const mod = await import('../src/index.js');
-        const first = mod.ensureInitialized();
+        const first  = mod.ensureInitialized();
         const second = mod.ensureInitialized();
 
         expect(first).toBe(second);

--- a/auth/test/unit-auth-coverage.test.ts
+++ b/auth/test/unit-auth-coverage.test.ts
@@ -69,9 +69,10 @@ describe('auth unit coverage', () => {
         expect(status2).toHaveBeenCalledWith(418);
     });
 
-    it('covers register unexpected error and refresh without token', async () => {
+    it('covers register unexpected error (non-unique-constraint) and refresh without token', async () => {
         process.env.JWT_SECRET = 'unit-secret';
         const repo = buildRepoMock();
+        // Código distinto a '23505' → debe llegar a UnexpectedError
         repo.createUser.mockRejectedValue({ code: 'SOMETHING_ELSE' });
 
         const service = new AuthService(repo as any);

--- a/auth/test/verify.test.ts
+++ b/auth/test/verify.test.ts
@@ -1,11 +1,35 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 import supertest from 'supertest';
 import jwt from 'jsonwebtoken';
 
 process.env.JWT_SECRET = 'test-secret';
-process.env.AUTH_DB_PATH = '/tmp/asw-auth-verify.db';
 
-let request: any;
+vi.mock('pg', async () => {
+    class MockClient {
+        async connect() { return undefined; }
+        async end()     { return undefined; }
+        async query()   { return { rows: [], rowCount: 0 }; }
+    }
+    class MockPool {
+        async query(sql: string) {
+            if (/CREATE TABLE|CREATE INDEX/i.test(sql)) return { rows: [], rowCount: 0 };
+            return { rows: [], rowCount: 0 };
+        }
+        async connect() {
+            return {
+                query: async (sql: string) => {
+                    const s = sql.trim().toUpperCase();
+                    if (s === 'BEGIN' || s === 'COMMIT' || s === 'ROLLBACK') return { rows: [], rowCount: 0 };
+                    return { rows: [], rowCount: 0 };
+                },
+                release: vi.fn(),
+            };
+        }
+    }
+    return { default: { Pool: MockPool, Client: MockClient } };
+});
+
+let request: ReturnType<typeof supertest>;
 
 beforeAll(async () => {
     const { app, ensureInitialized } = await import('../src/index.js');
@@ -24,7 +48,6 @@ describe('POST /api/auth/verify', () => {
         const res = await request
             .post('/api/auth/verify')
             .set('Authorization', 'Bearer invalid.token.here');
-
         expect(res.status).toBe(401);
         expect(res.body).toEqual({ valid: false });
     });
@@ -35,11 +58,9 @@ describe('POST /api/auth/verify', () => {
             'test-secret',
             { expiresIn: '1h', subject: '123', algorithm: 'HS256' }
         );
-
         const res = await request
             .post('/api/auth/verify')
             .set('Authorization', `Bearer ${token}`);
-
         expect(res.status).toBe(200);
         expect(res.body.valid).toBe(true);
         expect(res.body.claims.sub).toBe('123');
@@ -52,11 +73,9 @@ describe('POST /api/auth/verify', () => {
             'test-secret',
             { expiresIn: '1h', subject: '123', algorithm: 'HS256' }
         );
-
         const res = await request
             .post('/api/auth/verify')
             .send({ token });
-
         expect(res.status).toBe(200);
         expect(res.body.valid).toBe(true);
     });
@@ -67,11 +86,9 @@ describe('POST /api/auth/verify', () => {
             'test-secret',
             { expiresIn: '1h', subject: '123', algorithm: 'HS256' }
         );
-
         const res = await request
             .post('/api/auth/verify')
             .set('Authorization', `Bearer ${token}`);
-
         expect(res.status).toBe(401);
         expect(res.body).toEqual({ valid: false });
     });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,17 +12,42 @@ services:
     volumes:
       - ./users/data:/app/data
 
+  auth-db:
+    image: postgres:16-alpine
+    container_name: auth-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: authdb
+      POSTGRES_USER: auth_user
+      POSTGRES_PASSWORD: ${AUTH_DB_PASSWORD:-changeme}
+    volumes:
+      - auth-db-data:/var/lib/postgresql/data
+    expose:
+      - "5432"
+    networks:
+      - monitor-net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U auth_user -d authdb"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
   auth:
     build: ./auth
     container_name: auth
     image: ghcr.io/arquisoft/yovi_es1c-auth:latest
     environment:
       - JWT_SECRET=${JWT_SECRET}
-      - AUTH_DB_PATH=${AUTH_DB_PATH:-/app/auth/data/auth.db}
+      - PGHOST=auth-db
+      - PGPORT=5432
+      - PGDATABASE=authdb
+      - PGUSER=auth_user
+      - PGPASSWORD=${AUTH_DB_PASSWORD:-changeme}
     networks:
       - monitor-net
-    volumes:
-      - ./auth/data:/app/auth/data
+    depends_on:
+      auth-db:
+        condition: service_healthy
 
   webapp:
     build:
@@ -127,3 +152,6 @@ services:
 networks:
   monitor-net:
     driver: bridge
+
+volumes:
+  auth-db-data:

--- a/loadtests/README.md
+++ b/loadtests/README.md
@@ -17,7 +17,7 @@ They do not run automatically on push or PR — they must be triggered manually.
 
 ```bash
 # Auth flows (login, register, refresh)
-docker-compose -f loadtests/docker-compose.loadtest.yml --profile auth up
+docker-compose -f docker-compose.loadtest.yml --profile auth up
 
 # AI match flows (create match, move, stats)
 docker-compose -f docker-compose.loadtest.yml --profile game up

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -13,6 +13,11 @@ http {
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml;
     limit_req_zone $binary_remote_addr zone=api_limit:10m rate=10r/s;
 
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
     upstream users_backend {
         server users:3000;
     }
@@ -40,58 +45,45 @@ http {
         access_log /var/log/nginx/access.log;
         error_log /var/log/nginx/error.log;
 
-
         location /api/users/ {
             limit_req zone=api_limit burst=20 nodelay;
             proxy_pass http://users_backend/;
             proxy_http_version 1.1;
-
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-
             proxy_connect_timeout 60s;
             proxy_send_timeout 60s;
             proxy_read_timeout 60s;
-
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
             add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization' always;
-
-            if ($request_method = 'OPTIONS') {
-                return 204;
-            }
+            if ($request_method = 'OPTIONS') { return 204; }
         }
 
         location /api/gamey/ {
             limit_req zone=api_limit burst=20 nodelay;
             proxy_pass http://gamey_backend/;
             proxy_http_version 1.1;
-
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-
             proxy_connect_timeout 120s;
             proxy_send_timeout 120s;
             proxy_read_timeout 120s;
-
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
             add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization' always;
-
-            if ($request_method = 'OPTIONS') {
-                return 204;
-            }
+            if ($request_method = 'OPTIONS') { return 204; }
         }
 
         location /api/game/socket.io/ {
             proxy_pass http://gameservice_backend/socket.io/;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
+            proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -103,36 +95,26 @@ http {
             limit_req zone=api_limit burst=20 nodelay;
             proxy_pass http://gameservice_backend;
             proxy_http_version 1.1;
-
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
             add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization' always;
-
-            if ($request_method = 'OPTIONS') {
-                return 204;
-            }
+            if ($request_method = 'OPTIONS') { return 204; }
         }
 
         location /api/auth/ {
             proxy_pass http://auth_backend;
-
             proxy_set_header Authorization $http_authorization;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
             add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization' always;
-
-            if ($request_method = 'OPTIONS') {
-                return 204;
-            }
+            if ($request_method = 'OPTIONS') { return 204; }
         }
 
         location = /api/auth/verify {
@@ -152,12 +134,10 @@ http {
         location / {
             proxy_pass http://webapp_backend;
             proxy_http_version 1.1;
-
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-
             proxy_intercept_errors on;
             error_page 404 = @spa_fallback;
         }
@@ -166,7 +146,6 @@ http {
             rewrite ^ /index.html break;
             proxy_pass http://webapp_backend;
             proxy_http_version 1.1;
-
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
### Modified Auth — SQLite → PostgreSQL migration

+ Replaced sqlite3 with pg.Pool in CredentialsRepository — full async/await API, $1..$N placeholders
+ Wrapped multi-step operations (revokeOldestActiveSession, revokeSessionById, revokeAllUserSessions) in explicit BEGIN / COMMIT / ROLLBACK transactions via pool.connect()
+ Migrated init-auth-db.sql schema to PostgreSQL types (SERIAL, TIMESTAMPTZ, NOW(), IF NOT EXISTS)
+ Added auth-db service in docker-compose.yml (postgres:16-alpine) with healthcheck and named volume
+ Removed AUTH_DB_PATH / sqlite3 dependency; added AUTH_DB_PASSWORD to .env.example
+ Updated test mocks after migration:
  + auth-http.test.ts — rewrote in-memory pg mock; added replace(/\s+/g, ' ') normalization to handle multiline SQL; fixed WHERE id vs WHERE session_id regex collision; added BEGIN/COMMIT/ROLLBACK no-op handling in MockPool
  + credentials.repository.test.ts — declared mockQuery/mockConnect with vi.hoisted() to avoid temporal dead zone in vi.mock factory; switched MockPool to real class constructor
  + auth-service.test.ts — replaced SQLITE_CONSTRAINT with PG error code 23505 for duplicate user detection
  + extra-coverage.test.ts — call initAuthDatabase() without arguments; mock pg.Client instead of sqlite3.Database
  + verify.test.ts / bootstrap-index-verify.test.ts — added minimal pg mocks; removed getAuthDbPath test (function no longer exists)
  + unit-auth-coverage.test.ts — use 'SOMETHING_ELSE' error code to exercise UnexpectedError branch

---

### Load test results — Auth Service (50 VUs)

| Operation | Threshold | P95 before (SQLite) | P95 after (PostgreSQL) | Status |
|---|---|---|---|---|
| register | < 1500 ms | 3940 ms | **152 ms** | ✅ |
| login | < 1200 ms | 3580 ms | **118 ms** | ✅ |
| refresh | < 1200 ms | 1690 ms | **48 ms** | ✅ |

> 19 005 requests · 0 failures · 57 015 checks passed (100%) across 6335 full auth-flow iterations.