### PR TITLE
Added HTTPS support via Let's Encrypt + Certbot DNS-01 + DuckDNS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ VITE_GAME_ENGINE_API_URL=/api/gamey   # Rust game engine (stateless logic)
 VITE_GAME_SERVICE_API_URL=/api/game    # Game persistence service (matches, stats)
 VITE_AUTH_API_URL=/api/auth            # Authentication service
 VITE_USERS_API_URL=/api/users          # User profile service
+# DuckDNS
+DUCKDNS_TOKEN=tu-token-de-duckdns
+DUCKDNS_DOMAIN=yovi-es1c
+CERTBOT_EMAIL=tu@email.com

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -283,16 +283,33 @@ jobs:
           registry: ghcr.io
           workdir: gameservice
           tags: "latest,${{ env.IMAGE_TAG }}"
-
+  resolve-host:
+    name: Resolve deploy host from DuckDNS
+    runs-on: ubuntu-latest
+    needs: [ docker-push-users, docker-push-auth, docker-push-webapp, docker-push-gamey, docker-push-gameservice ]
+    outputs:
+      deploy_host: ${{ steps.dns.outputs.host }}
+    steps:
+      - name: Resolve DuckDNS domain
+        id: dns
+        run: |
+          echo "Resolving ${{ secrets.DUCKDNS_DOMAIN }}.duckdns.org..."
+          IP=$(dig +short ${{ secrets.DUCKDNS_DOMAIN }}.duckdns.org | tail -1)
+          if [ -z "$IP" ]; then
+            echo "ERROR: Could not resolve domain. Is the VM running and DuckDNS updated?"
+            exit 1
+          fi
+          echo "Resolved IP: $IP"
+          echo "host=$IP" >> $GITHUB_OUTPUT
   deploy:
     name: Deploy over SSH
     runs-on: ubuntu-latest
-    needs: [ docker-push-users, docker-push-auth, docker-push-webapp, docker-push-gamey, docker-push-gameservice ]
+    needs: [ resolve-host ]
     steps:
       - name: Deploy over SSH
         uses: appleboy/ssh-action@v1.0.0
         with:
-          host: ${{ secrets.DEPLOY_HOST }}
+          host: ${{ needs.resolve-host.outputs.deploy_host }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_KEY }}
           envs: JWT_SECRET,IMAGE_TAG,GAME_DB_PASSWORD,AUTH_DB_PASSWORD
@@ -338,9 +355,9 @@ jobs:
             export IMAGE_TAG="$IMAGE_TAG"
             export GAME_DB_PASSWORD="$GAME_DB_PASSWORD"
             export AUTH_DB_PASSWORD="$AUTH_DB_PASSWORD"
-            docker compose down
-            docker compose pull
-            docker compose up -d
+            docker-compose down 
+            docker-compose pull
+            docker-compose up -d
         env:
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           IMAGE_TAG: ${{ env.IMAGE_TAG }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,14 +137,36 @@ services:
         condition: service_healthy
     networks:
       - monitor-net
+  certbot:
+    build: ./nginx/certbot
+    container_name: certbot
+    volumes:
+      - letsencrypt:/etc/letsencrypt
+    environment:
+      - DUCKDNS_TOKEN=${DUCKDNS_TOKEN}
+    command: >
+      certonly
+      --non-interactive
+      --agree-tos
+      --email ${CERTBOT_EMAIL:-admin@example.com}
+      --authenticator dns-duckdns
+      --dns-duckdns-token ${DUCKDNS_TOKEN}
+      --dns-duckdns-propagation-seconds 60
+      -d ${DUCKDNS_DOMAIN}.duckdns.org
+    profiles:
+      - certbot
+    networks:
+      - monitor-net
 
   nginx:
     image: nginx:alpine
     container_name: nginx_proxy
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - letsencrypt:/etc/letsencrypt:ro
       - ./webapp/dist:/usr/share/nginx/html:ro
     depends_on:
       - webapp
@@ -188,3 +210,4 @@ networks:
 volumes:
   auth-db-data:
   game-db-data:
+  letsencrypt:

--- a/gameservice/src/services/OnlineSessionService.ts
+++ b/gameservice/src/services/OnlineSessionService.ts
@@ -478,6 +478,12 @@ export class OnlineSessionService {
     await this.handleMove(matchId, userId, randomMove, expectedVersion);
   }
 
+  private secureRandomInt(max: number): number {
+    const array = new Uint32Array(1);
+    crypto.getRandomValues(array);
+    return array[0] % max;
+  }
+
   private pickRandomMove(layout: string): MoveCommand | null {
     const emptyCells: MoveCommand[] = [];
 
@@ -492,7 +498,7 @@ export class OnlineSessionService {
 
     if (emptyCells.length === 0) return null;
 
-    const randomIndex = Math.floor(Math.random() * emptyCells.length);
+    const randomIndex = this.secureRandomInt(emptyCells.length);
     return emptyCells[randomIndex];
   }
 

--- a/gameservice/test/online-session-service.test.ts
+++ b/gameservice/test/online-session-service.test.ts
@@ -169,11 +169,17 @@ describe('OnlineSessionService', () => {
   it('handleTurnTimeout performs a random valid move when it is current player turn', async () => {
     const { service } = await setup();
     const moveSpy = vi.spyOn(service, 'handleMove');
-    vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    vi.spyOn(crypto, 'getRandomValues').mockImplementation((array) => {
+      (array as Uint32Array)[0] = 0;
+      return array as Uint32Array;
+    });
 
     await service.handleTurnTimeout('m1', 1, 0);
 
     expect(moveSpy).toHaveBeenCalledWith('m1', 1, { row: 0, col: 0 }, 0);
+
+    vi.restoreAllMocks();
   });
 
   it('handleTurnTimeout skips when version does not match', async () => {

--- a/nginx/certbot/Dockerfile
+++ b/nginx/certbot/Dockerfile
@@ -1,0 +1,2 @@
+FROM certbot/certbot:latest
+RUN pip install certbot-dns-duckdns

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -11,6 +11,7 @@ http {
     gzip on;
     gzip_vary on;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml;
+
     geo $limit_key {
         default        $binary_remote_addr;
         172.18.0.0/16  "";
@@ -46,6 +47,32 @@ http {
     server {
         listen 80;
         server_name _;
+
+        location /health {
+            access_log off;
+            return 200 "healthy\n";
+            add_header Content-Type text/plain;
+        }
+
+        location / {
+            return 301 https://$host$request_uri;
+        }
+    }
+
+    server {
+        listen 443 ssl;
+        server_name _;
+
+        ssl_certificate     /etc/letsencrypt/live/yovi-es1c.duckdns.org/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/yovi-es1c.duckdns.org/privkey.pem;
+        ssl_protocols       TLSv1.2 TLSv1.3;
+        ssl_ciphers         HIGH:!aNULL:!MD5;
+        ssl_prefer_server_ciphers on;
+        ssl_session_cache   shared:SSL:10m;
+        ssl_session_timeout 10m;
+
+        # Habilitar tras verificar que HTTPS funciona correctamente:
+        # add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
 
         access_log /var/log/nginx/access.log;
         error_log /var/log/nginx/error.log;

--- a/nginx/scripts/renew.sh
+++ b/nginx/scripts/renew.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Updated automatically Lets Encrypt CA to ensure HTTPS safety
+set -e
+COMPOSE_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+echo "[$(date)] Iniciando renovación de certificado..."
+cd "$COMPOSE_DIR"
+docker-compose run --rm certbot renew
+docker-compose exec nginx nginx -s reload
+echo "[$(date)] Renovación completada."


### PR DESCRIPTION
+ Added nginx/certbot/Dockerfile with certbot-dns-duckdns plugin
+ Added certbot service to docker-compose.yml
+ Added letsencrypt named volume shared between certbot and nginx
+ Exposed port 443 in nginx service
+ Updated nginx.conf: HTTP server redirects to HTTPS, HTTPS server block with TLS 1.2/1.3, ssl_session_cache and all existing proxy/upstream config
+ Added nginx/scripts/renew.sh for automatic renewal via cron
+ Certificate issued for yovi-es1c.duckdns.org by Let's Encrypt CA E8
+ Fixed OnlineSessionService hotspot